### PR TITLE
Fix #107: Add missing ActiveAssignment requirements processing to import functions

### DIFF
--- a/EasyPIM/internal/functions/Import-EntraRoleSettings.ps1
+++ b/EasyPIM/internal/functions/Import-EntraRoleSettings.ps1
@@ -31,12 +31,15 @@ function Import-EntraRoleSettings  {
     }
     $csv = Import-Csv $path
 
-    $csv | ForEach-Object {
-        $rules = @()
+    $csv | ForEach-Object {        $rules = @()
         $rules += Set-ActivationDuration $_.ActivationDuration -entrarole
 
         $enablementRules = $_.EnablementRules.Split(',')
         $rules += Set-ActivationRequirement $enablementRules -entraRole
+
+        # Add missing ActiveAssignmentRequirement processing
+        $activeAssignmentRequirements = $_.ActiveAssignmentRequirement.Split(',')
+        $rules += Set-ActiveAssignmentRequirement $activeAssignmentRequirements -entraRole
 
        # $approvers = @()
        # $approvers += $_.approvers

--- a/EasyPIM/internal/functions/Import-Settings.ps1
+++ b/EasyPIM/internal/functions/Import-Settings.ps1
@@ -21,13 +21,16 @@ function Import-Setting ($path) {
     }
     $csv = Import-Csv $path
 
-    $csv | ForEach-Object {
-        $rules = @()
+    $csv | ForEach-Object {        $rules = @()
         $script:scope=$_.policyID -replace "/providers.*"
 
         $rules += Set-ActivationDuration $_.ActivationDuration
         $enablementRules = $_.EnablementRules.Split(',')
         $rules += Set-ActivationRequirement $enablementRules
+
+        $activeAssignmentRules = $_.ActiveAssignmentRules.Split(',')
+        $rules += Set-ActiveAssignmentRequirement $activeAssignmentRules
+
         #$approvers = @()
         #$approvers += $_.approvers
         $rules += Set-ApprovalFromCSV $_.ApprovalRequired $_.Approvers


### PR DESCRIPTION
- Fix Import-EntraRoleSettings.ps1: Add ActiveAssignmentRequirement processing
- Fix Import-Settings.ps1: Add ActiveAssignmentRules processing
- Both import functions now properly handle active assignment requirements (MFA, justification)
- Export->Import workflow now complete for both Entra Roles and Azure Resource Roles
- All 7858 tests passing