### PR TITLE
fix(core): add Key Vault compatibility to Get-EasyPIMConfiguration

### DIFF
--- a/EasyPIM/EasyPIM.psd1
+++ b/EasyPIM/EasyPIM.psd1
@@ -6,7 +6,7 @@
 RootModule = 'EasyPIM.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.0.12'
+ModuleVersion = '2.0.13'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()


### PR DESCRIPTION
- Extend Key Vault secret retrieval compatibility for newer Az.KeyVault module versions
- Add backward compatibility for both SecretValueText (old) and SecretValue (new) properties
- Implement proper SecureString handling with ConvertFrom-SecureString and Marshal fallback
- Add input validation for null/empty secret values with clear error messages
- Ensures Invoke-EasyPIMOrchestrator Key Vault functionality works across module versions
- Bump EasyPIM core version to 2.0.13

This complements the orchestrator-specific fix in Test-PIMPolicyDrift and ensures consistent Key Vault access across both core and orchestrator modules.