### PR TITLE
chore: bump versions for PowerShell 5.1 compatibility release

### DIFF
--- a/EasyPIM.Orchestrator/EasyPIM.Orchestrator.psd1
+++ b/EasyPIM.Orchestrator/EasyPIM.Orchestrator.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'EasyPIM.Orchestrator.psm1'
-    ModuleVersion = '1.4.1'
+    ModuleVersion = '1.4.2'
     GUID              = 'b6f9b3c9-bc6a-4d4b-8c51-7c45d42157cd'
     Author            = 'Loïc MICHEL'
     CompanyName       = 'EasyPIM'

--- a/EasyPIM/EasyPIM.psd1
+++ b/EasyPIM/EasyPIM.psd1
@@ -6,7 +6,7 @@
 RootModule = 'EasyPIM.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.0.24'
+ModuleVersion = '2.0.25'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/session_starter.md
+++ b/session_starter.md
@@ -27,9 +27,9 @@ orchestrator-vX.Y.Z
 
 ## 🧠 **Assistant Memory & Context**
 
-### **Current State (2025-09-08)**
-- **EasyPIM Core**: v2.0.21 (tagged as `core-v2.0.21`) ✅ PUBLISHED
-- **EasyPIM.Orchestrator**: v1.3.6 (tagged as `orchestrator-v1.3.6`) ✅ PUBLISHED
+### **Current State (2025-09-09)**
+- **EasyPIM Core**: v2.0.25 (preparing to tag as `core-v2.0.25`) 🚀 PENDING
+- **EasyPIM.Orchestrator**: v1.4.2 (preparing to tag as `orchestrator-v1.4.2`) 🚀 PENDING
 - **Branch**: `main` (hotfix merged and published)
 - **Major Bug**: ✅ RESOLVED - ARM API userType auto-detection implemented
 
@@ -91,6 +91,7 @@ orchestrator-vX.Y.Z
 
 | Date | Key Achievement |
 |------|-----------------|
+| 2025-09-09 | ✅ **PS5.1 COMPATIBILITY**: Fixed Unicode emoji parsing errors, ARM SecureString conversion, and principal validation |
 | 2025-09-08 | 🔥 **MAJOR BREAKTHROUGH**: Discovered & fixed orchestrator hardcoding "Type=user" preventing auto-detection |
 | 2025-09-08 | ✅ **PR CREATED**: Drift detection boolean comparison fix (false positives resolved) |
 | 2025-09-08 | ✅ **VALIDATED**: Test-PIMPolicyDrift now shows 12/12 policies match (zero drift) |


### PR DESCRIPTION
- EasyPIM Core: v2.0.24 → v2.0.25
- EasyPIM.Orchestrator: v1.4.1 → v1.4.2
- Update session starter with PS5.1 compatibility achievements

Includes fixes:
- ARM API SecureString conversion for cross-PowerShell compatibility
- Unicode emoji removal for PS5.1 parsing compatibility
- Direct Graph API calls for principal validation
- Module loading syntax error resolution

Ready for tagging:
- core-v2.0.25
- orchestrator-v1.4.2