### PR TITLE
fix(backup): gracefully handle 404 for RG-scoped roles (#223)

### DIFF
--- a/EasyPIM/EasyPIM.psd1
+++ b/EasyPIM/EasyPIM.psd1
@@ -6,7 +6,7 @@
 RootModule = 'EasyPIM.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.0.39'
+ModuleVersion = '2.0.40'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()


### PR DESCRIPTION
- Added try-catch in Backup-PIMAzureResourcePolicy to detect 404 errors
- When role has PIM policy at child scope (e.g., resource group), skip with warning
- Prevents backup failure when custom roles use assignableScopes at RG level
- Version bump to 2.0.40

Closes #223