### PR TITLE
Add role assignment condition (ABAC) support for Azure resource roles

### DIFF
--- a/EasyPIM.Orchestrator/functions/Invoke-EasyPIMOrchestrator.ps1
+++ b/EasyPIM.Orchestrator/functions/Invoke-EasyPIMOrchestrator.ps1
@@ -603,6 +603,11 @@ function Invoke-EasyPIMOrchestrator {
 				Write-Verbose -Message ("[DEBUG] Skipping scope GUID: $guid")
 				continue
 			}
+			# Skip if GUID appears inside an ABAC condition expression (role definition IDs, not principals)
+			if ($configJson -match "GuidEquals\s*\{[^}]*$guid|RoleDefinitionId[^`"]*$guid") {
+				Write-Verbose -Message ("[DEBUG] Skipping condition GUID (role definition reference): $guid")
+				continue
+			}
 			$principalGuids += $guid
 			Write-Verbose -Message ("[DEBUG] Found potential principal GUID: $guid")
 		}

--- a/EasyPIM.Orchestrator/functions/Invoke-EasyPIMOrchestrator.ps1
+++ b/EasyPIM.Orchestrator/functions/Invoke-EasyPIMOrchestrator.ps1
@@ -589,10 +589,30 @@ function Invoke-EasyPIMOrchestrator {
 		Write-Verbose -Message ("[DEBUG] Extracting GUIDs from configuration using regex...")
 		Write-Verbose -Message ("[DEBUG] Config JSON length: $($configJson.Length) characters")
 
-		# Regex to find all GUIDs, but exclude those in scope paths
+		# Regex to find all GUIDs, but exclude those in scope paths and condition expressions
 		$guidPattern = '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
 		$allGuids = [System.Text.RegularExpressions.Regex]::Matches($configJson, $guidPattern) | ForEach-Object { $_.Value } | Sort-Object -Unique
 		Write-Verbose -Message ("[DEBUG] Found $($allGuids.Count) total GUIDs in configuration")
+
+		# Collect non-principal GUIDs from ABAC condition expressions (e.g. RoleDefinitionId references)
+		# PrincipalId GUIDs in conditions ARE real principals and should still be validated
+		$conditionRoleDefGuids = @{}
+		$conditionPattern = '"[Cc]ondition"\s*:\s*"([^"]*)"'
+		$conditionMatches = [System.Text.RegularExpressions.Regex]::Matches($configJson, $conditionPattern)
+		foreach ($cm in $conditionMatches) {
+			$conditionValue = $cm.Groups[1].Value
+			# Extract GUIDs from RoleDefinitionId contexts only — these are role definitions, not principals
+			# Matches any GUID operator (GuidEquals and any future variants) after RoleDefinitionId
+			$roleDefPattern = 'RoleDefinitionId\].*?\{([^}]*' + $guidPattern + '[^}]*)\}'
+			$roleDefMatches = [System.Text.RegularExpressions.Regex]::Matches($conditionValue, $roleDefPattern)
+			foreach ($rdm in $roleDefMatches) {
+				$guidsInBlock = [System.Text.RegularExpressions.Regex]::Matches($rdm.Groups[1].Value, $guidPattern)
+				foreach ($g in $guidsInBlock) { $conditionRoleDefGuids[$g.Value] = $true }
+			}
+		}
+		if ($conditionRoleDefGuids.Count -gt 0) {
+			Write-Verbose -Message ("[DEBUG] Found $($conditionRoleDefGuids.Count) RoleDefinitionId GUIDs inside ABAC conditions (excluded from validation)")
+		}
 
 		# Filter out GUIDs that are in scope paths (subscriptions, management groups, etc.)
 		$principalGuids = @()
@@ -603,9 +623,9 @@ function Invoke-EasyPIMOrchestrator {
 				Write-Verbose -Message ("[DEBUG] Skipping scope GUID: $guid")
 				continue
 			}
-			# Skip if GUID appears inside an ABAC condition expression (role definition IDs, not principals)
-			if ($configJson -match "GuidEquals\s*\{[^}]*$guid|RoleDefinitionId[^`"]*$guid") {
-				Write-Verbose -Message ("[DEBUG] Skipping condition GUID (role definition reference): $guid")
+			# Skip if GUID is a RoleDefinitionId reference inside an ABAC condition expression
+			if ($conditionRoleDefGuids.ContainsKey($guid)) {
+				Write-Verbose -Message ("[DEBUG] Skipping ABAC RoleDefinitionId GUID: $guid")
 				continue
 			}
 			$principalGuids += $guid

--- a/EasyPIM.Orchestrator/internal/functions/EPO_Invoke-ResourceAssignments.ps1
+++ b/EasyPIM.Orchestrator/internal/functions/EPO_Invoke-ResourceAssignments.ps1
@@ -173,12 +173,31 @@
 
 					if ($existsActiveData.Count -gt 0 -or $existsEligData.Count -gt 0) {
 						$foundType = if ($existsActiveData.Count -gt 0) { 'Active' } else { 'Eligible' }
-						if ($whatIf) {
-							Write-Host "  ✅ [MATCH] Assignment exists: $ctx [Found: $foundType]" -ForegroundColor Green
+						$existingMatch = if ($existsActiveData.Count -gt 0) { $existsActiveData[0] } else { $existsEligData[0] }
+
+						# Compare conditions: if the desired condition differs from what's deployed, remove and recreate
+						$desiredCondition = if ($a.condition) { $a.condition } else { $null }
+						$existingCondition = if ($existingMatch.Condition) { $existingMatch.Condition } else { $null }
+
+						if ($desiredCondition -ne $existingCondition) {
+							Write-Host "  🔄 Condition changed: $ctx [Found: $foundType] — removing old assignment to recreate with updated condition" -ForegroundColor Cyan
+							if (-not $whatIf) {
+								$removeParams = @{ tenantID = $TenantId; subscriptionID = $SubscriptionId; scope = $scope; rolename = $roleName; principalID = $a.principalId }
+								if ($foundType -eq 'Active') {
+									Remove-PIMAzureResourceActiveAssignment @removeParams
+								} else {
+									Remove-PIMAzureResourceEligibleAssignment @removeParams
+								}
+							}
+							# Fall through to creation below
 						} else {
-							Write-Host "  ⏭️ Skipped existing: $ctx [Found: $foundType]" -ForegroundColor Yellow
+							if ($whatIf) {
+								Write-Host "  ✅ [MATCH] Assignment exists: $ctx [Found: $foundType]" -ForegroundColor Green
+							} else {
+								Write-Host "  ⏭️ Skipped existing: $ctx [Found: $foundType]" -ForegroundColor Yellow
+							}
+							$summary.Skipped++; continue
 						}
-						$summary.Skipped++; continue
 					}
 				} catch {
 					$VerbosePreference = $script:originalVerbosePreference

--- a/EasyPIM.Orchestrator/internal/functions/EPO_Invoke-ResourceAssignments.ps1
+++ b/EasyPIM.Orchestrator/internal/functions/EPO_Invoke-ResourceAssignments.ps1
@@ -194,15 +194,19 @@
 				$sb = {
 					if ($a.assignmentType -match 'Active') {
 						$params = @{ tenantID = $TenantId; subscriptionID = $SubscriptionId; scope = $scope; rolename = $roleName; principalID = $a.principalId }
-						if ($a.duration)   { $params.duration = $a.duration }
-						if ($a.permanent)  { $params.permanent = $true }
-						if ($a.justification) { $params.justification = $a.justification }
+						if ($a.duration)        { $params.duration = $a.duration }
+						if ($a.permanent)       { $params.permanent = $true }
+						if ($a.justification)   { $params.justification = $a.justification }
+						if ($a.condition)       { $params.condition = $a.condition }
+						if ($a.conditionVersion){ $params.conditionVersion = $a.conditionVersion }
 						New-PIMAzureResourceActiveAssignment @params | Out-Null
 					} else {
 						$params = @{ tenantID = $TenantId; subscriptionID = $SubscriptionId; scope = $scope; rolename = $roleName; principalID = $a.principalId }
-						if ($a.duration)   { $params.duration = $a.duration }
-						if ($a.permanent)  { $params.permanent = $true }
-						if ($a.justification) { $params.justification = $a.justification }
+						if ($a.duration)        { $params.duration = $a.duration }
+						if ($a.permanent)       { $params.permanent = $true }
+						if ($a.justification)   { $params.justification = $a.justification }
+						if ($a.condition)       { $params.condition = $a.condition }
+						if ($a.conditionVersion){ $params.conditionVersion = $a.conditionVersion }
 						New-PIMAzureResourceEligibleAssignment @params | Out-Null
 					}
 				}

--- a/EasyPIM.Orchestrator/internal/functions/Initialize-EasyPIMAssignments.ps1
+++ b/EasyPIM.Orchestrator/internal/functions/Initialize-EasyPIMAssignments.ps1
@@ -82,6 +82,13 @@ function Initialize-EasyPIMAssignments {
                             $assignmentObj | Add-Member -MemberType NoteProperty -Name 'Duration' -Value $assignment.duration
                         }
 
+                        # Add condition if specified
+                        if ($assignment.PSObject.Properties['condition'] -and $assignment.condition) {
+                            $assignmentObj | Add-Member -MemberType NoteProperty -Name 'condition' -Value $assignment.condition
+                            $condVer = if ($assignment.PSObject.Properties['conditionVersion'] -and $assignment.conditionVersion) { $assignment.conditionVersion } else { '2.0' }
+                            $assignmentObj | Add-Member -MemberType NoteProperty -Name 'conditionVersion' -Value $condVer
+                        }
+
                         # Split by assignment type
                         if ($assignment.assignmentType -eq "Active") {
                             $null = $result.AzureRolesActive.Add($assignmentObj)

--- a/EasyPIM/Documentation/Configuration-Schema.md
+++ b/EasyPIM/Documentation/Configuration-Schema.md
@@ -202,7 +202,9 @@ Inline role policy objects accept the same properties as templates (ActivationDu
             "principalType": "string (required - 'User', 'Group', or 'ServicePrincipal')",
             "assignmentType": "string (required - 'Eligible' or 'Active')",
             "duration": "string (required for Active assignments - ISO 8601 duration)",
-            "justification": "string (optional - reason for assignment)"
+            "justification": "string (optional - reason for assignment)",
+            "condition": "string (optional - ABAC role assignment condition expression)",
+            "conditionVersion": "string (optional - condition language version, defaults to '2.0')"
           }
         ]
       }
@@ -247,7 +249,17 @@ Inline role policy objects accept the same properties as templates (ActivationDu
 - **Source**: Azure AD portal, PowerShell (`Get-AzADUser`, `Get-AzADGroup`), Graph API
 - **Never use**: Email addresses, display names, UPNs
 
+### Role Assignment Conditions (ABAC)
+
+Azure RBAC supports [attribute-based access control (ABAC) conditions](https://learn.microsoft.com/en-us/azure/role-based-access-control/conditions-overview) on role assignments. Conditions let you constrain what a principal can do with a role — for example, restricting a Storage Blob Data Contributor to a specific container, or limiting a Role Based Access Control Administrator to assign only certain roles.
+
+- **`condition`**: The condition expression string. Use the Azure Portal condition editor to build and copy the expression.
+- **`conditionVersion`**: The condition language version. Currently always `"2.0"`. Omit to use the default.
+
+Only supported for `Assignments.AzureRoles`. Entra ID and Group role assignments do not support conditions.
+
 ### Azure Resource Scopes
+
 - **Subscription**: `/subscriptions/{subscription-id}`
 - **Resource Group**: `/subscriptions/{subscription-id}/resourceGroups/{rg-name}`
 - **Resource**: `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/{provider}/{resource}`
@@ -326,6 +338,19 @@ Inline role policy objects accept the same properties as templates (ActivationDu
             "assignmentType": "Active",
             "duration": "PT8H",
             "justification": "Temporary access for project"
+          }
+        ]
+      },
+      {
+        "roleName": "Storage Blob Data Contributor",
+        "scope": "/subscriptions/12345678-1234-1234-1234-123456789012",
+        "assignments": [
+          {
+            "principalId": "87654321-4321-4321-4321-210987654321",
+            "principalType": "ServicePrincipal",
+            "assignmentType": "Eligible",
+            "condition": "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:name] StringEquals 'my-container'))",
+            "conditionVersion": "2.0"
           }
         ]
       }

--- a/EasyPIM/Documentation/Configuration-Schema.md
+++ b/EasyPIM/Documentation/Configuration-Schema.md
@@ -251,7 +251,7 @@ Inline role policy objects accept the same properties as templates (ActivationDu
 
 ### Role Assignment Conditions (ABAC)
 
-Azure RBAC supports [attribute-based access control (ABAC) conditions](https://learn.microsoft.com/en-us/azure/role-based-access-control/conditions-overview) on role assignments. Conditions let you constrain what a principal can do with a role — for example, restricting a Storage Blob Data Contributor to a specific container, or limiting a Role Based Access Control Administrator to assign only certain roles.
+Azure RBAC supports [attribute-based access control (ABAC) conditions](https://learn.microsoft.com/en-us/azure/role-based-access-control/conditions-overview) on role assignments. Conditions allow fine-grained access control — for example, restricting a Storage Blob Data Contributor to a specific container, or constraining which roles a [Role Based Access Control Administrator](https://learn.microsoft.com/en-us/azure/role-based-access-control/delegate-role-assignments-overview) can assign. Not all roles support conditions — for details see the linked documentation.
 
 - **`condition`**: The condition expression string. Use the Azure Portal condition editor to build and copy the expression.
 - **`conditionVersion`**: The condition language version. Currently always `"2.0"`. Omit to use the default.

--- a/EasyPIM/Documentation/Step-by-step-Guide.md
+++ b/EasyPIM/Documentation/Step-by-step-Guide.md
@@ -1024,6 +1024,8 @@ This example uses the [delegated role assignment management](https://learn.micro
 - `condition` (string, optional): The ABAC condition expression. Use the Azure Portal condition editor to build and copy it.
 - `conditionVersion` (string, optional): The condition language version. Currently always `"2.0"`. Defaults to `"2.0"` if omitted.
 
+**Conditions on unsupported roles:** If you add a condition targeting actions that the role does not have (e.g. a storage blob condition on the Reader role), the Azure API rejects the request with a `400 Bad Request`. The assignment fails but the orchestrator pipeline continues processing remaining assignments.
+
 **Condition change detection:** The orchestrator compares the desired condition with the existing one. If they differ, the old assignment is removed and recreated with the updated condition (the Azure PIM API does not support in-place condition updates).
 
 **Legacy format:** Conditions are also supported in the flat `AzureRoles` format:

--- a/EasyPIM/Documentation/Step-by-step-Guide.md
+++ b/EasyPIM/Documentation/Step-by-step-Guide.md
@@ -951,6 +951,98 @@ Multiple principals
 }
 ```
 
+### Role Assignment Conditions (ABAC)
+
+Azure RBAC supports [attribute-based access control (ABAC) conditions](https://learn.microsoft.com/en-us/azure/role-based-access-control/conditions-overview) that constrain what a principal can do with a role assignment. For example, you can restrict a Storage Blob Data Contributor to only read blobs in a specific container, or constrain a [Role Based Access Control Administrator](https://learn.microsoft.com/en-us/azure/role-based-access-control/delegate-role-assignments-overview) to only assign a specific set of roles.
+
+> **Scope:** Conditions are only supported for Azure role assignments (`Assignments.AzureRoles`). They do not apply to Entra ID roles or Group roles.
+
+> **Supported roles:** Not all roles support conditions. For details on which roles and actions support conditions, see [Azure ABAC conditions overview](https://learn.microsoft.com/en-us/azure/role-based-access-control/conditions-overview) and [Delegate role assignment management with conditions](https://learn.microsoft.com/en-us/azure/role-based-access-control/delegate-role-assignments-overview).
+
+**How to get the condition expression:**
+
+1. In the Azure Portal, create a role assignment with a condition using the visual condition editor
+2. Switch to the **Advanced** (code) tab to see the raw expression string
+3. Copy this expression into your config JSON
+
+Alternatively, retrieve an existing condition from a role assignment using `Get-PIMAzureResourceEligibleAssignment` (which now returns `Condition` and `ConditionVersion` properties).
+
+**Example: Storage Blob Data Contributor restricted to a specific container**
+
+```jsonc
+{
+  "Assignments": {
+    "AzureRoles": [
+      {
+        "roleName": "Storage Blob Data Contributor",
+        "scope": "/subscriptions/<sub-guid>",
+        "assignments": [
+          {
+            "principalId": "33333333-3333-3333-3333-333333333333",
+            "assignmentType": "Eligible",
+            "justification": "Scoped blob access",
+            // ABAC condition — see https://learn.microsoft.com/en-us/azure/role-based-access-control/conditions-overview
+            "condition": "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:name] StringEquals 'my-container'))",
+            "conditionVersion": "2.0"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Example: Role Based Access Control Administrator with constrained delegation**
+
+This example uses the [delegated role assignment management](https://learn.microsoft.com/en-us/azure/role-based-access-control/delegate-role-assignments-overview) pattern. The condition constrains the principal to only assign (and remove) a specific set of roles — following the principle of least privilege instead of granting unrestricted User Access Administrator or Owner.
+
+```json
+{
+  "Assignments": {
+    "AzureRoles": [
+      {
+        "roleName": "Role Based Access Control Administrator",
+        "scope": "/providers/Microsoft.Management/managementGroups/<mg-name>",
+        "assignments": [
+          {
+            "principalId": "11111111-2222-3333-4444-555555555555",
+            "assignmentType": "Eligible",
+            "condition": "((!(ActionMatches{'Microsoft.Authorization/roleAssignments/write'})) OR (@Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAnyValues:GuidEquals {acdd72a7-3385-48ef-bd42-f606fba81ae7, 4a9ae827-6dc8-4573-8ac7-8239d42aa03f, 9980e02c-c2be-4d73-94e8-173b1dc7cf3c, f1a07417-d97a-45cb-824c-7a7467783830})) AND ((!(ActionMatches{'Microsoft.Authorization/roleAssignments/delete'})) OR (@Resource[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAnyValues:GuidEquals {acdd72a7-3385-48ef-bd42-f606fba81ae7, 4a9ae827-6dc8-4573-8ac7-8239d42aa03f, 9980e02c-c2be-4d73-94e8-173b1dc7cf3c, f1a07417-d97a-45cb-824c-7a7467783830}))",
+            "conditionVersion": "2.0"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+> The GUIDs are Azure built-in [role definition IDs](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles): `acdd72a7-...` = Reader, `4a9ae827-...` = Tag Contributor, `9980e02c-...` = Virtual Machine Contributor, `f1a07417-...` = Managed Identity Operator. The condition ensures this principal can only assign and remove those four roles — not Owner, User Access Administrator, or any other privileged role. In practice you will have more roles in this list; build these conditions using the [Azure Portal condition editor](https://learn.microsoft.com/en-us/azure/role-based-access-control/delegate-role-assignments-portal) or copy them from an existing assignment.
+
+**Condition properties:**
+
+- `condition` (string, optional): The ABAC condition expression. Use the Azure Portal condition editor to build and copy it.
+- `conditionVersion` (string, optional): The condition language version. Currently always `"2.0"`. Defaults to `"2.0"` if omitted.
+
+**Condition change detection:** The orchestrator compares the desired condition with the existing one. If they differ, the old assignment is removed and recreated with the updated condition (the Azure PIM API does not support in-place condition updates).
+
+**Legacy format:** Conditions are also supported in the flat `AzureRoles` format:
+
+```jsonc
+{
+  "AzureRoles": [
+    {
+      "PrincipalId": "33333333-3333-3333-3333-333333333333",
+      "Rolename": "Storage Blob Data Contributor",
+      "Scope": "/subscriptions/<sub-guid>",
+      // ABAC condition — see https://learn.microsoft.com/en-us/azure/role-based-access-control/conditions-overview
+      "Condition": "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:name] StringEquals 'my-container'))",
+      "ConditionVersion": "2.0"
+    }
+  ]
+}
+```
+
 <a id="step-8"></a>
 ## Step 8 — Optional: Groups (Policies + Assignments)
 

--- a/EasyPIM/EasyPIM.psd1
+++ b/EasyPIM/EasyPIM.psd1
@@ -6,7 +6,7 @@
 RootModule = 'EasyPIM.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.2.2'
+ModuleVersion = '2.3.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/EasyPIM/config/enhanced-sample-config.json
+++ b/EasyPIM/config/enhanced-sample-config.json
@@ -23,6 +23,7 @@
             "PrincipalId": "a621fbf5-d750-4e68-b898-2e2b41cd45c6",
             "Rolename": "Storage Blob Data Contributor",
             "Scope": "/subscriptions/442734fd-2546-4a3b-b4c7-f351bd5ff93a",
+            "_comment": "ABAC role assignment condition. See https://learn.microsoft.com/en-us/azure/role-based-access-control/conditions-overview",
             "Condition": "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:name] StringEquals 'my-container'))",
             "ConditionVersion": "2.0"
         }
@@ -383,13 +384,14 @@
                 ]
             },
             {
-                "roleName": "Key Vault Secrets Officer",
-                "scope": "/subscriptions/442734fd-2546-4a3b-b4c7-f351bd5ff93a/resourceGroups/demo-rg/providers/Microsoft.KeyVault/vaults/demo-kv",
+                "roleName": "Storage Queue Data Contributor",
+                "scope": "/subscriptions/442734fd-2546-4a3b-b4c7-f351bd5ff93a",
                 "assignments": [
                     {
                         "principalId": "a621fbf5-d750-4e68-b898-2e2b41cd45c6",
                         "assignmentType": "Eligible",
-                        "condition": "((!(ActionMatches{'Microsoft.KeyVault/vaults/secrets/getSecret/action'})) OR (@Resource[Microsoft.KeyVault/vaults/secrets:name] StringEquals 'my-secret'))",
+                        "_comment": "ABAC condition — restrict queue message processing. See https://learn.microsoft.com/en-us/azure/role-based-access-control/conditions-overview",
+                        "condition": "((!(ActionMatches{'Microsoft.Storage/storageAccounts/queueServices/queues/messages/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/queueServices/queues:name] StringEquals 'my-queue'))",
                         "conditionVersion": "2.0"
                     }
                 ]

--- a/EasyPIM/config/enhanced-sample-config.json
+++ b/EasyPIM/config/enhanced-sample-config.json
@@ -18,6 +18,13 @@
             ],
             "Rolename": "Reader",
             "Scope": "/subscriptions/442734fd-2546-4a3b-b4c7-f351bd5ff93a"
+        },
+        {
+            "PrincipalId": "a621fbf5-d750-4e68-b898-2e2b41cd45c6",
+            "Rolename": "Storage Blob Data Contributor",
+            "Scope": "/subscriptions/442734fd-2546-4a3b-b4c7-f351bd5ff93a",
+            "Condition": "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:name] StringEquals 'my-container'))",
+            "ConditionVersion": "2.0"
         }
     ],
     "AzureRolesActive": [
@@ -360,5 +367,33 @@
                 "notificationLevel": "All"
             }
         }
+    },
+    "Assignments": {
+        "AzureRoles": [
+            {
+                "roleName": "Storage Blob Data Contributor",
+                "scope": "/subscriptions/442734fd-2546-4a3b-b4c7-f351bd5ff93a",
+                "assignments": [
+                    {
+                        "principalId": "a621fbf5-d750-4e68-b898-2e2b41cd45c6",
+                        "assignmentType": "Eligible",
+                        "condition": "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:name] StringEquals 'my-container'))",
+                        "conditionVersion": "2.0"
+                    }
+                ]
+            },
+            {
+                "roleName": "Key Vault Secrets Officer",
+                "scope": "/subscriptions/442734fd-2546-4a3b-b4c7-f351bd5ff93a/resourceGroups/demo-rg/providers/Microsoft.KeyVault/vaults/demo-kv",
+                "assignments": [
+                    {
+                        "principalId": "a621fbf5-d750-4e68-b898-2e2b41cd45c6",
+                        "assignmentType": "Eligible",
+                        "condition": "((!(ActionMatches{'Microsoft.KeyVault/vaults/secrets/getSecret/action'})) OR (@Resource[Microsoft.KeyVault/vaults/secrets:name] StringEquals 'my-secret'))",
+                        "conditionVersion": "2.0"
+                    }
+                ]
+            }
+        ]
     }
 }

--- a/EasyPIM/config/sample-config.json
+++ b/EasyPIM/config/sample-config.json
@@ -27,6 +27,7 @@
       "PrincipalId": "a621fbf5-d750-4e68-b898-2e2b41cd45c6", // PIM5
       "Rolename": "Storage Blob Data Contributor",
       "Scope": "/subscriptions/442734fd-2546-4a3b-b4c7-f351bd5ff93a",
+      "_comment": "ABAC role assignment condition. See https://learn.microsoft.com/en-us/azure/role-based-access-control/conditions-overview",
       "Condition": "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:name] StringEquals 'my-container'))",
       "ConditionVersion": "2.0"
       }

--- a/EasyPIM/config/sample-config.json
+++ b/EasyPIM/config/sample-config.json
@@ -22,6 +22,13 @@
       "PrincipalId": "aec7e1be-91cf-41bf-b849-10e5ada8353c", // Admin group
       "Rolename": "Owner",
       "Scope": "/providers/Microsoft.Management/managementGroups/all_sub" //management group scope
+      },
+      {
+      "PrincipalId": "a621fbf5-d750-4e68-b898-2e2b41cd45c6", // PIM5
+      "Rolename": "Storage Blob Data Contributor",
+      "Scope": "/subscriptions/442734fd-2546-4a3b-b4c7-f351bd5ff93a",
+      "Condition": "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:name] StringEquals 'my-container'))",
+      "ConditionVersion": "2.0"
       }
       /*,
       {

--- a/EasyPIM/functions/Copy-PIMAzureResourceEligibleAssignment.ps1
+++ b/EasyPIM/functions/Copy-PIMAzureResourceEligibleAssignment.ps1
@@ -83,7 +83,18 @@ function Copy-PIMAzureResourceEligibleAssignment {
         $assignments=get-PIMAzureResourceEligibleAssignment -tenantID $tenantID -scope $scope -assignee $from
         $assignments | ForEach-Object {
             Write-Verbose "Copying assignment from $from to $to at scope $($_.scopeId) with role $($_.rolename)"
-            New-PIMAzureResourceEligibleAssignment -tenantID $tenantID -subscriptionID $subscriptionID -scope $_.scopeId -rolename $_.rolename -principalID $to
+            $params = @{
+                tenantID       = $tenantID
+                subscriptionID = $subscriptionID
+                scope          = $_.scopeId
+                rolename       = $_.rolename
+                principalID    = $to
+            }
+            if ($_.Condition) {
+                $params.condition = $_.Condition
+                if ($_.ConditionVersion) { $params.conditionVersion = $_.ConditionVersion }
+            }
+            New-PIMAzureResourceEligibleAssignment @params
         }
 
     }

--- a/EasyPIM/functions/Get-PIMAzureResourceActiveAssignment.ps1
+++ b/EasyPIM/functions/Get-PIMAzureResourceActiveAssignment.ps1
@@ -142,13 +142,15 @@ function Get-PIMAzureResourceActiveAssignment {
                     "ScopeId"        = $_.expandedproperties.scope.id;
                     "ScopeName"      = $_.expandedproperties.scope.displayName;
                     "ScopeType"      = $_.expandedproperties.scope.type;
-                    "Status"         = $_.Status;
-                    "createdOn"      = $_.createdOn
-                    "startDateTime"  = $_.startDateTime
-                    "endDateTime"    = $end
-                    "updatedOn"      = $_.updatedOn
-                    "memberType"     = $_.memberType
-                    "id"             = $id
+                    "Status"           = $_.Status;
+                    "createdOn"        = $_.createdOn
+                    "startDateTime"    = $_.startDateTime
+                    "endDateTime"      = $end
+                    "updatedOn"        = $_.updatedOn
+                    "memberType"       = $_.memberType
+                    "id"               = $id
+                    "Condition"        = $_.condition
+                    "ConditionVersion" = $_.conditionVersion
                 }
 
 

--- a/EasyPIM/functions/Get-PIMAzureResourceEligibleAssignment.ps1
+++ b/EasyPIM/functions/Get-PIMAzureResourceEligibleAssignment.ps1
@@ -154,13 +154,15 @@ function Get-PIMAzureResourceEligibleAssignment {
                     "ScopeId"        = $_.expandedproperties.scope.id;
                     "ScopeName"      = $_.expandedproperties.scope.displayName;
                     "ScopeType"      = $_.expandedproperties.scope.type;
-                    "Status"         = $_.Status;
-                    "createdOn"      = $_.createdOn
-                    "startDateTime"  = $_.startDateTime
-                    "endDateTime"    = $end
-                    "updatedOn"      = $_.updatedOn
-                    "memberType"     = $_.memberType
-                    "id"             = $id
+                    "Status"           = $_.Status;
+                    "createdOn"        = $_.createdOn
+                    "startDateTime"    = $_.startDateTime
+                    "endDateTime"      = $end
+                    "updatedOn"        = $_.updatedOn
+                    "memberType"       = $_.memberType
+                    "id"               = $id
+                    "Condition"        = $_.condition
+                    "ConditionVersion" = $_.conditionVersion
                 }
 
 

--- a/EasyPIM/functions/New-PIMAzureResourceActiveAssignment.ps1
+++ b/EasyPIM/functions/New-PIMAzureResourceActiveAssignment.ps1
@@ -23,6 +23,11 @@
     Use this parameter if you want a permanent assignement (no expiration)
     .Parameter justification
     justification
+    .Parameter condition
+    ABAC condition expression string for role assignment conditions (e.g. to restrict access by resource attribute).
+    See https://learn.microsoft.com/en-us/azure/role-based-access-control/conditions-overview
+    .Parameter conditionVersion
+    Version of the condition language. Defaults to "2.0" when condition is provided.
 
 
     .Example
@@ -37,6 +42,10 @@
     PS> New-PIMAzureResourceActiveAssigment -tenantID $tenantID -scope "/subscriptions/$subscriptionId/resourceGroups/demo-rg" -rolename "Reader" -principalName "user@contoso.com"
 
     Resolve the provided principal name to its object ID before creating the active assignment.
+
+    PS> New-PIMAzureResourceActiveAssignment -tenantID $tenantID -subscriptionID $subscriptionId -rolename "Storage Blob Data Contributor" -principalID 3604fe63-cb67-4b60-99c9-707d46ab9092 -condition "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:name] StringEquals 'my-container'))" -conditionVersion "2.0"
+
+    Create an active assignment with an ABAC condition restricting blob access to a specific container.
 
     .Link
     https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-resource-roles-assign-roles
@@ -104,7 +113,19 @@ function New-PIMAzureResourceActiveAssignment {
         [Parameter(ParameterSetName = 'ByPrincipalName')]
         [switch]
         # the assignment will not expire
-        $permanent
+        $permanent,
+
+        [Parameter(ParameterSetName = 'ByPrincipalId')]
+        [Parameter(ParameterSetName = 'ByPrincipalName')]
+        [string]
+        # ABAC condition expression for role assignment conditions
+        $condition,
+
+        [Parameter(ParameterSetName = 'ByPrincipalId')]
+        [Parameter(ParameterSetName = 'ByPrincipalName')]
+        [string]
+        # Condition language version, defaults to "2.0" when condition is provided
+        $conditionVersion
 
     )
 
@@ -183,6 +204,17 @@ function New-PIMAzureResourceActiveAssignment {
         $type = "NoExpiration"
     }
 
+    $conditionBlock = ''
+    if ($PSBoundParameters.Keys.Contains('condition')) {
+        if (-not $PSBoundParameters.Keys.Contains('conditionVersion')) {
+            $conditionVersion = '2.0'
+        }
+        $escapedCondition = $condition -replace '"', '\"'
+        $conditionBlock = ',
+        "condition": "' + $escapedCondition + '",
+        "conditionVersion": "' + $conditionVersion + '"'
+    }
+
     $body = '
 {
     "properties": {
@@ -197,7 +229,8 @@ function New-PIMAzureResourceActiveAssignment {
                 "endDateTime": null,
                 "duration": "'+ $duration + '"
             }
-        }
+        }' + $conditionBlock + '
+    }
 }
 '
     $guid = New-Guid

--- a/EasyPIM/functions/New-PIMAzureResourceEligibleAssignment.ps1
+++ b/EasyPIM/functions/New-PIMAzureResourceEligibleAssignment.ps1
@@ -23,6 +23,11 @@
     Use this parameter if you want a permanent assignement (no expiration)
     .Parameter justification
     justification
+    .Parameter condition
+    ABAC condition expression string for role assignment conditions (e.g. to restrict access by resource attribute).
+    See https://learn.microsoft.com/en-us/azure/role-based-access-control/conditions-overview
+    .Parameter conditionVersion
+    Version of the condition language. Defaults to "2.0" when condition is provided.
 
 
     .Example
@@ -37,6 +42,10 @@
     PS> New-PIMAzureResourceEligibleAssignment -tenantID $tenantID -scope "/subscriptions/$subscriptionId/resourceGroups/demo-rg" -rolename "Reader" -principalName "app@contoso.com"
 
     Resolve the principal name to its object ID before creating the eligible assignment.
+
+    PS> New-PIMAzureResourceEligibleAssignment -tenantID $tenantID -subscriptionID $subscriptionId -rolename "Storage Blob Data Contributor" -principalID 3604fe63-cb67-4b60-99c9-707d46ab9092 -condition "((!(ActionMatches{'Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read'})) OR (@Resource[Microsoft.Storage/storageAccounts/blobServices/containers:name] StringEquals 'my-container'))" -conditionVersion "2.0"
+
+    Create an eligible assignment with an ABAC condition restricting blob access to a specific container.
 
 
     .Link
@@ -105,7 +114,19 @@ function New-PIMAzureResourceEligibleAssignment {
         [Parameter(ParameterSetName = 'ByPrincipalName')]
         [switch]
         # the assignment will not expire
-        $permanent
+        $permanent,
+
+        [Parameter(ParameterSetName = 'ByPrincipalId')]
+        [Parameter(ParameterSetName = 'ByPrincipalName')]
+        [string]
+        # ABAC condition expression for role assignment conditions
+        $condition,
+
+        [Parameter(ParameterSetName = 'ByPrincipalId')]
+        [Parameter(ParameterSetName = 'ByPrincipalName')]
+        [string]
+        # Condition language version, defaults to "2.0" when condition is provided
+        $conditionVersion
 
     )
 
@@ -173,6 +194,17 @@ function New-PIMAzureResourceEligibleAssignment {
             $type = "NoExpiration"
         }
 
+        $conditionBlock = ''
+        if ($PSBoundParameters.Keys.Contains('condition')) {
+            if (-not $PSBoundParameters.Keys.Contains('conditionVersion')) {
+                $conditionVersion = '2.0'
+            }
+            $escapedCondition = $condition -replace '"', '\"'
+            $conditionBlock = ',
+        "condition": "' + $escapedCondition + '",
+        "conditionVersion": "' + $conditionVersion + '"'
+        }
+
         $body = '
 {
     "properties": {
@@ -187,7 +219,7 @@ function New-PIMAzureResourceEligibleAssignment {
                 "endDateTime": null,
                 "duration": "'+ $duration + '"
             }
-        }
+        }' + $conditionBlock + '
     }
 }
 '


### PR DESCRIPTION
## Summary

  This PR adds support for Azure RBAC role assignment conditions to eligible and active PIM assignments for Azure resources. Conditions (also known as ABAC — attribute-based access control) allow constraining what a      
  principal can do with a role, for example restricting a Storage Blob Data Contributor to a specific container or limiting a Role Based Access Control Administrator to assign only certain roles to certain principal
  types.                                                                                                                                                                                                                     
                                                                                                                                 
  The feature maps to the **"Add role assignment condition"** dialog in the Azure Portal PIM interface.                                                                                                                      

  fixes #265 
     
  ## Changes                                                                                                                                                                                                                 
                                                                                                                                  
  ### Core module                        

  - `New-PIMAzureResourceEligibleAssignment` — added optional `-condition` and `-conditionVersion` parameters; condition block is injected into the ARM request body                                                         
  - `New-PIMAzureResourceActiveAssignment` — same; also fixed a pre-existing missing closing brace in the JSON body
  - `Get-PIMAzureResourceEligibleAssignment` — `Condition` and `ConditionVersion` are now included in the output object                                                                                                      
  - `Get-PIMAzureResourceActiveAssignment` — same                                                                                                                                                                            
  - `Copy-PIMAzureResourceEligibleAssignment` — conditions are carried over from source to target assignment                                                                                                                 
                                                                                                                                                                                                                             
  ### Orchestrator                                                                                                                
                                                                                                                                                                                                                             
  - `EPO_Invoke-ResourceAssignments` — passes `condition`/`conditionVersion` through to `New-*` functions when present                                                                                                       
  - `Initialize-EasyPIMAssignments` — extracts `condition`/`conditionVersion` from `Assignments.AzureRoles[].assignments[]` config blocks; defaults `conditionVersion` to `"2.0"` when absent
  - `Invoke-EasyPIMOrchestrator` — fixed a false-positive principal validation warning: the GUID regex sweep was picking up role definition GUIDs embedded in condition strings (e.g. `ForAnyOfAnyValues:GuidEquals          
  {acdd72a7-...}`) and treating them as invalid principals. The fix pre-extracts GUIDs from `RoleDefinitionId` contexts within condition values and excludes only those from validation. `PrincipalId` GUIDs in conditions   
  are still validated.                                                                                                                                                                                                       
                                                                                                                                                                                                                             
  ### Config examples                                                                                                             
                                         
  `sample-config.json` and `enhanced-sample-config.json` updated with condition examples for both legacy and `Assignments`-block formats.                                                                                    
   
  ## Usage                                                                                                                                                                                                                   
                                                                                                                                  
  ```json                                
  {
    "Assignments": {
      "AzureRoles": [
        {
          "roleName": "Role Based Access Control Administrator",
          "scope": "/providers/Microsoft.Management/managementGroups/my-mg",                                                                                                                                                 
          "assignments": [                                                                                                                                                                                                   
            {                                                                                                                                                                                                                
              "principalId": "<object-id>",                                                                                                                                                                                  
              "assignmentType": "Eligible",                                                                                       
              "condition": "((!(ActionMatches{'Microsoft.Authorization/roleAssignments/write'})) OR (@Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] ForAnyOfAnyValues:GuidEquals                         
  {acdd72a7-3385-48ef-bd42-f606fba81ae7}))",                                                                                                                                                                                 
              "conditionVersion": "2.0"                                                                                                                                                                                      
            }                                                                                                                                                                                                                
          ]                                                                                                                       
        }                                                                                                                                                                                                                    
      ]                                                                                                                           
    }                                    
  }
```
  Tests

  14 new Pester tests across 4 files:                                                                                                                                                                                        
  
  - tests/orchestrator/Initialize-EasyPIMAssignments.Tests.ps1 (5 tests) — condition/conditionVersion mapping, default version, Active assignments, Entra roles excluded                                                     
  - tests/functions/New-PIMAzureResourceEligibleAssignment.Tests.ps1 (4 tests) — JSON body construction, version default, double-quote escaping
  - tests/functions/Get-PIMAzureResourceEligibleAssignment.Tests.ps1 (3 tests) — condition in output, null when absent, stripped in summary mode                                                                             
  - tests/functions/Copy-PIMAzureResourceEligibleAssignment.Tests.ps1 (2 tests) — condition pass-through present/absent                                                                                                      
                                                                                                                                                                                                                             
  Full suite: Tests Passed: 7606 — no regressions against the pre-existing baseline.                                                                                                                                         
                                                                                                                                  
  Documentation                                                                                                                                                                                                              
                                                                                                                                  
  - Configuration-Schema.md updated with condition/conditionVersion fields in the Assignments.AzureRoles schema, a new ABAC conditions section under Common Data Types, and a complete example.                              
   
  Version                                                                                                                                                                                                                    
  ```                                                                                                                                
  EasyPIM.psd1: 2.2.2 → 2.3.0                                                                                                                                                                                                
  ```