### PR TITLE
Feature: proactive pre-expiry renewal for Azure resource role PIM assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [EasyPIM Core 2.4.0 & EasyPIM.Orchestrator 1.7.0] - 2026-07-02
+
+### Added
+
+- **Pre-expiry assignment renewal (Azure resource roles)**: New `Invoke-EasyPIMAssignmentRenewal` (Orchestrator) proactively extends eligible and active Azure resource role PIM assignments that are declared in an orchestrator configuration and expiring within a threshold (default 14 days), using the ARM `AdminExtend` request type (no approval required, safe to schedule unattended). Contributed by [@AzureStackNerd](https://github.com/AzureStackNerd).
+  - New core cmdlets `Update-PIMAzureResourceEligibleAssignment` and `Update-PIMAzureResourceActiveAssignment` submit the `AdminExtend` request, resolving the target schedule and honouring the role policy maximum duration.
+  - Only assignments declared in the configuration are extended; new end date is clamped to the role policy maximum; supports `-WhatIf` and returns a summary object.
+  - v1 is Azure resource roles only; Entra directory roles and PIM-for-Groups are designed for but not yet implemented.
+
 ## [EasyPIM Core 2.3.1 & EasyPIM.Orchestrator 1.6.0] - 2026-04-12
 
 ### Added

--- a/EasyPIM.Orchestrator/EasyPIM.Orchestrator.psd1
+++ b/EasyPIM.Orchestrator/EasyPIM.Orchestrator.psd1
@@ -21,7 +21,8 @@
         'Test-PIMPolicyDrift',
         'Test-PIMEndpointDiscovery',
         'Get-EasyPIMConfiguration',
-        'Disable-EasyPIMTelemetry'
+        'Disable-EasyPIMTelemetry',
+        'Invoke-EasyPIMAssignmentRenewal'
     )
     AliasesToExport   = @()
     CmdletsToExport   = @()

--- a/EasyPIM.Orchestrator/EasyPIM.Orchestrator.psd1
+++ b/EasyPIM.Orchestrator/EasyPIM.Orchestrator.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'EasyPIM.Orchestrator.psm1'
-    ModuleVersion = '1.6.0'
+    ModuleVersion = '1.7.0'
     GUID              = 'b6f9b3c9-bc6a-4d4b-8c51-7c45d42157cd'
     Author            = 'Loïc MICHEL'
     CompanyName       = 'EasyPIM'

--- a/EasyPIM.Orchestrator/EasyPIM.Orchestrator.psm1
+++ b/EasyPIM.Orchestrator/EasyPIM.Orchestrator.psm1
@@ -14,5 +14,6 @@ Export-ModuleMember -Function @(
 	'Test-PIMPolicyDrift',
 	'Test-PIMEndpointDiscovery',
 	'Disable-EasyPIMTelemetry',
-	'Get-EasyPIMConfiguration'
+	'Get-EasyPIMConfiguration',
+	'Invoke-EasyPIMAssignmentRenewal'
 )

--- a/EasyPIM.Orchestrator/functions/Invoke-EasyPIMAssignmentRenewal.ps1
+++ b/EasyPIM.Orchestrator/functions/Invoke-EasyPIMAssignmentRenewal.ps1
@@ -133,10 +133,23 @@ function Invoke-EasyPIMAssignmentRenewal {
         } | Select-Object -First 1
         if (-not $match) { continue }  # declared but not currently live -> New-EasyPIMAssignments handles creation, not us
 
-        # Skip permanent / not-expiring
-        if ($match.endDateTime -eq 'permanent' -or [string]::IsNullOrWhiteSpace($match.endDateTime)) { continue }
+        # Skip permanent / not-expiring. The getter returns endDateTime as a [datetime]
+        # (ConvertFrom-Json coerces the ISO value) for time-bound assignments, or the
+        # literal string 'permanent'. Use the [datetime] directly; only string-parse as a
+        # fallback, and then with InvariantCulture so a non-US session culture cannot
+        # mis-read or silently drop the value.
+        $edt = $match.endDateTime
+        if ($null -eq $edt) { continue }
         $end = $null
-        try { $end = [datetime]::Parse($match.endDateTime).ToUniversalTime() } catch { continue }
+        if ($edt -is [datetime]) {
+            $end = ([datetime]$edt).ToUniversalTime()
+        } else {
+            $edtStr = [string]$edt
+            if ($edtStr -eq 'permanent' -or [string]::IsNullOrWhiteSpace($edtStr)) { continue }
+            $parsedEnd = [datetime]::MinValue
+            if (-not [datetime]::TryParse($edtStr, [System.Globalization.CultureInfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::RoundtripKind, [ref]$parsedEnd)) { continue }
+            $end = $parsedEnd.ToUniversalTime()
+        }
         if ($end -gt $cutoff) { continue }
 
         $summary.FoundExpiring++

--- a/EasyPIM.Orchestrator/functions/Invoke-EasyPIMAssignmentRenewal.ps1
+++ b/EasyPIM.Orchestrator/functions/Invoke-EasyPIMAssignmentRenewal.ps1
@@ -70,7 +70,14 @@ function Invoke-EasyPIMAssignmentRenewal {
     }
     $processed = Initialize-EasyPIMAssignments -Config $config
 
-    if (-not $processed.Assignments -or -not ($processed.Assignments.PSObject.Properties.Name -contains 'AzureRoles') -or -not $processed.Assignments.AzureRoles) {
+    # Consume the normalized flat arrays produced by Initialize-EasyPIMAssignments:
+    #   $processed.AzureRoles       -> eligible Azure resource role assignments
+    #   $processed.AzureRolesActive -> active Azure resource role assignments
+    # Each item is a clean object exposing .RoleName, .Scope, .PrincipalId, .AssignmentType.
+    $eligibleItems = @($processed.AzureRoles)
+    $activeItems   = @($processed.AzureRolesActive)
+
+    if ($eligibleItems.Count -eq 0 -and $activeItems.Count -eq 0) {
         Write-Host "No Azure role assignments declared in configuration; nothing to renew." -ForegroundColor Yellow
         return $summary
     }
@@ -78,91 +85,113 @@ function Invoke-EasyPIMAssignmentRenewal {
     $now = (Get-Date).ToUniversalTime()
     $cutoff = $now.AddDays($ThresholdDays)
 
-    foreach ($roleBlock in $processed.Assignments.AzureRoles) {
-        $roleName = $roleBlock.RoleName; if (-not $roleName) { $roleName = $roleBlock.roleName }
-        $scope    = $roleBlock.Scope;    if (-not $scope)    { $scope = $roleBlock.scope }
-        if (-not $roleName -or -not $scope) { continue }
+    # Per-scope live-assignment caches (avoid N+1 fetches) and per-scope|role policy cache.
+    $eligibleCache = @{}
+    $activeCache   = @{}
+    $policyCache   = @{}
 
-        # Pre-fetch live assignments once per scope
-        $liveEligible = @()
-        $liveActive   = @()
-        try { $liveEligible = @(Get-PIMAzureResourceEligibleAssignment -tenantID $TenantId -subscriptionID $SubscriptionId -scope $scope -ErrorAction SilentlyContinue) } catch { Write-Verbose "[Renewal] eligible fetch failed for ${scope}: $($_.Exception.Message)" }
-        try { $liveActive   = @(Get-PIMAzureResourceActiveAssignment   -tenantID $TenantId -subscriptionID $SubscriptionId -scope $scope -ErrorAction SilentlyContinue) } catch { Write-Verbose "[Renewal] active fetch failed for ${scope}: $($_.Exception.Message)" }
+    # Iterate eligible then active items from the normalized arrays.
+    $work = @()
+    foreach ($item in $eligibleItems) { $work += [pscustomobject]@{ Item = $item; IsActive = $false } }
+    foreach ($item in $activeItems)   { $work += [pscustomobject]@{ Item = $item; IsActive = $true  } }
 
-        # Read policy once per role/scope
-        $policy = $null
-        try { $policy = Get-PIMAzureResourcePolicy -tenantID $TenantId -scope $scope -rolename $roleName } catch { Write-Verbose "[Renewal] policy fetch failed for $roleName@${scope}: $($_.Exception.Message)" }
+    foreach ($entry in $work) {
+        $item     = $entry.Item
+        $isActive = $entry.IsActive
 
-        foreach ($a in ($roleBlock.assignments | Where-Object { $_ })) {
-            $principalId = $a.principalId
-            $isActive = ($a.assignmentType -match 'Active')
+        $roleName    = $item.RoleName
+        $scope       = $item.Scope
+        $principalId = $item.PrincipalId
+        if (-not $roleName -or -not $scope -or -not $principalId) { continue }
 
-            # Match against live assignments of the same kind
-            $liveSet = if ($isActive) { $liveActive } else { $liveEligible }
-            $match = $liveSet | Where-Object {
-                $_.PrincipalId -eq $principalId -and $_.RoleName -eq $roleName -and $_.ScopeId -eq $scope
-            } | Select-Object -First 1
-            if (-not $match) { continue }  # declared but not currently live -> New-EasyPIMAssignments handles creation, not us
-
-            # Skip permanent / not-expiring
-            if ($match.endDateTime -eq 'permanent' -or [string]::IsNullOrWhiteSpace($match.endDateTime)) { continue }
-            $end = $null
-            try { $end = [datetime]::Parse($match.endDateTime).ToUniversalTime() } catch { continue }
-            if ($end -gt $cutoff) { continue }
-
-            $summary.FoundExpiring++
-            $ctx = "Azure/$roleName@$scope/$principalId [$($a.assignmentType)]"
-
-            # Compute new end date from policy max
-            $maxDurationIso = if ($isActive) { $policy.MaximumActiveAssignmentDuration } else { $policy.MaximumEligibleAssignmentDuration }
-            $allowPermanent = if ($isActive) { $policy.AllowPermanentActiveAssignment } else { $policy.AllowPermanentEligibleAssignment }
-
-            if ([string]::IsNullOrWhiteSpace($maxDurationIso)) {
-                $reason = if ("$allowPermanent" -eq 'true') { "policy allows permanent (no max duration) - consider a permanent assignment to remove the need to extend" } else { "no maximum duration in policy" }
-                Write-Host "  SKIP  $ctx : $reason" -ForegroundColor Yellow
-                $summary.Skipped++
-                $summary.Details += [pscustomobject]@{ Context = $ctx; Action = 'Skipped'; Reason = $reason }
-                continue
+        # Live assignments cached once per scope (per kind)
+        if ($isActive) {
+            if (-not $activeCache.ContainsKey($scope)) {
+                $activeCache[$scope] = @()
+                try { $activeCache[$scope] = @(Get-PIMAzureResourceActiveAssignment -tenantID $TenantId -subscriptionID $SubscriptionId -scope $scope -ErrorAction SilentlyContinue) } catch { Write-Verbose "[Renewal] active fetch failed for ${scope}: $($_.Exception.Message)" }
             }
+            $liveSet = $activeCache[$scope]
+        } else {
+            if (-not $eligibleCache.ContainsKey($scope)) {
+                $eligibleCache[$scope] = @()
+                try { $eligibleCache[$scope] = @(Get-PIMAzureResourceEligibleAssignment -tenantID $TenantId -subscriptionID $SubscriptionId -scope $scope -ErrorAction SilentlyContinue) } catch { Write-Verbose "[Renewal] eligible fetch failed for ${scope}: $($_.Exception.Message)" }
+            }
+            $liveSet = $eligibleCache[$scope]
+        }
 
-            $maxTs = $null
-            try { $maxTs = [System.Xml.XmlConvert]::ToTimeSpan($maxDurationIso) } catch { }
-            if ($null -eq $maxTs) {
-                Write-Host "  SKIP  $ctx : could not parse policy max duration '$maxDurationIso'" -ForegroundColor Yellow
-                $summary.Skipped++
-                $summary.Details += [pscustomobject]@{ Context = $ctx; Action = 'Skipped'; Reason = "unparsable max duration '$maxDurationIso'" }
-                continue
-            }
-            $newEnd = ($now.Add($maxTs)).ToString("yyyy-MM-ddTHH:mm:ssZ")
-            if ("$allowPermanent" -eq 'true') {
-                Write-Host "  NOTE  $ctx : policy allows permanent; extending to policy max ($maxDurationIso). A permanent assignment would remove the need to extend." -ForegroundColor DarkCyan
-            }
+        # Policy cached once per scope|role
+        $policyKey = "$scope|$roleName"
+        if (-not $policyCache.ContainsKey($policyKey)) {
+            $policyCache[$policyKey] = $null
+            try { $policyCache[$policyKey] = Get-PIMAzureResourcePolicy -tenantID $TenantId -scope $scope -rolename $roleName } catch { Write-Verbose "[Renewal] policy fetch failed for $roleName@${scope}: $($_.Exception.Message)" }
+        }
+        $policy = $policyCache[$policyKey]
 
-            if ($WhatIfPreference) {
-                Write-Host "  What if: Extend $ctx to $newEnd" -ForegroundColor Cyan
-                $summary.Details += [pscustomobject]@{ Context = $ctx; Action = 'PlannedExtend'; NewEnd = $newEnd }
-                continue
-            }
+        # Match against live assignments of the same kind
+        $match = $liveSet | Where-Object {
+            $_.PrincipalId -eq $principalId -and $_.RoleName -eq $roleName -and $_.ScopeId -eq $scope
+        } | Select-Object -First 1
+        if (-not $match) { continue }  # declared but not currently live -> New-EasyPIMAssignments handles creation, not us
 
-            $params = @{
-                tenantID       = $TenantId
-                subscriptionID = $SubscriptionId
-                scope          = $scope
-                rolename       = $roleName
-                principalID    = $principalId
-                newEndDateTime = $newEnd
-            }
-            try {
-                if ($isActive) { Update-PIMAzureResourceActiveAssignment @params }
-                else           { Update-PIMAzureResourceEligibleAssignment @params }
-                Write-Host "  EXTENDED  $ctx -> $newEnd" -ForegroundColor Green
-                $summary.Extended++
-                $summary.Details += [pscustomobject]@{ Context = $ctx; Action = 'Extended'; NewEnd = $newEnd }
-            } catch {
-                Write-Host "  FAILED  $ctx : $($_.Exception.Message)" -ForegroundColor Red
-                $summary.Skipped++
-                $summary.Details += [pscustomobject]@{ Context = $ctx; Action = 'Failed'; Reason = $_.Exception.Message }
-            }
+        # Skip permanent / not-expiring
+        if ($match.endDateTime -eq 'permanent' -or [string]::IsNullOrWhiteSpace($match.endDateTime)) { continue }
+        $end = $null
+        try { $end = [datetime]::Parse($match.endDateTime).ToUniversalTime() } catch { continue }
+        if ($end -gt $cutoff) { continue }
+
+        $summary.FoundExpiring++
+        $kind = if ($isActive) { 'Active' } else { 'Eligible' }
+        $ctx = "Azure/$roleName $principalId @ $scope [$kind]"
+
+        # Compute new end date from policy max
+        $maxDurationIso = if ($isActive) { $policy.MaximumActiveAssignmentDuration } else { $policy.MaximumEligibleAssignmentDuration }
+        $allowPermanent = if ($isActive) { $policy.AllowPermanentActiveAssignment } else { $policy.AllowPermanentEligibleAssignment }
+
+        if ([string]::IsNullOrWhiteSpace($maxDurationIso)) {
+            $reason = if ("$allowPermanent" -eq 'true') { "policy allows permanent (no max duration) - consider a permanent assignment to remove the need to extend" } else { "no maximum duration in policy" }
+            Write-Host "  SKIP  $ctx : $reason" -ForegroundColor Yellow
+            $summary.Skipped++
+            $summary.Details += [pscustomobject]@{ Context = $ctx; Action = 'Skipped'; Reason = $reason }
+            continue
+        }
+
+        $maxTs = $null
+        try { $maxTs = [System.Xml.XmlConvert]::ToTimeSpan($maxDurationIso) } catch { }
+        if ($null -eq $maxTs) {
+            Write-Host "  SKIP  $ctx : could not parse policy max duration '$maxDurationIso'" -ForegroundColor Yellow
+            $summary.Skipped++
+            $summary.Details += [pscustomobject]@{ Context = $ctx; Action = 'Skipped'; Reason = "unparsable max duration '$maxDurationIso'" }
+            continue
+        }
+        $newEnd = ($now.Add($maxTs)).ToString("yyyy-MM-ddTHH:mm:ssZ")
+        if ("$allowPermanent" -eq 'true') {
+            Write-Host "  NOTE  $ctx : policy allows permanent; extending to policy max ($maxDurationIso). A permanent assignment would remove the need to extend." -ForegroundColor DarkCyan
+        }
+
+        if ($WhatIfPreference) {
+            Write-Host "  What if: Extend $ctx to $newEnd" -ForegroundColor Cyan
+            $summary.Details += [pscustomobject]@{ Context = $ctx; Action = 'PlannedExtend'; NewEnd = $newEnd }
+            continue
+        }
+
+        $params = @{
+            tenantID       = $TenantId
+            subscriptionID = $SubscriptionId
+            scope          = $scope
+            rolename       = $roleName
+            principalID    = $principalId
+            newEndDateTime = $newEnd
+        }
+        try {
+            if ($isActive) { Update-PIMAzureResourceActiveAssignment @params }
+            else           { Update-PIMAzureResourceEligibleAssignment @params }
+            Write-Host "  EXTENDED  $ctx -> $newEnd" -ForegroundColor Green
+            $summary.Extended++
+            $summary.Details += [pscustomobject]@{ Context = $ctx; Action = 'Extended'; NewEnd = $newEnd }
+        } catch {
+            Write-Host "  FAILED  $ctx : $($_.Exception.Message)" -ForegroundColor Red
+            $summary.Skipped++
+            $summary.Details += [pscustomobject]@{ Context = $ctx; Action = 'Failed'; Reason = $_.Exception.Message }
         }
     }
 

--- a/EasyPIM.Orchestrator/functions/Invoke-EasyPIMAssignmentRenewal.ps1
+++ b/EasyPIM.Orchestrator/functions/Invoke-EasyPIMAssignmentRenewal.ps1
@@ -1,0 +1,172 @@
+<#
+.SYNOPSIS
+Extends Azure resource role PIM assignments (eligible and active) that are declared in an EasyPIM orchestrator
+configuration and are expiring within a threshold (default 14 days).
+.DESCRIPTION
+Loads an EasyPIM orchestrator configuration (file or Key Vault), lists the live eligible and active Azure resource
+role assignments per configured scope, keeps those that are both declared in the configuration AND expiring within
+-ThresholdDays, then submits an ARM AdminExtend request for each (via Update-PIMAzureResource*Assignment). Admin
+extension requires no approval, so this is safe to schedule unattended (pipeline/runbook).
+
+The new end date is set to now + the role policy maximum assignment duration (clamped to the policy). If a role
+policy allows permanent assignment but defines no maximum duration, the assignment is skipped with a note
+recommending a permanent assignment instead. Assignments that exist in Azure but are not declared in the
+configuration are never touched.
+
+v1 supports Azure resource roles only. Entra directory roles and PIM-for-Groups are not yet supported.
+.PARAMETER ConfigFilePath
+Path to the JSON/JSONC orchestrator configuration file.
+.PARAMETER KeyVaultName
+Key Vault holding the configuration secret (alternative to -ConfigFilePath).
+.PARAMETER SecretName
+Key Vault secret name that stores the configuration.
+.PARAMETER TenantId
+Target tenant GUID. Falls back to $env:tenantid.
+.PARAMETER SubscriptionId
+Target subscription GUID. Falls back to $env:subscriptionid.
+.PARAMETER ThresholdDays
+Extend assignments expiring within this many days. Default 14 (matching PIM's own notification window).
+.EXAMPLE
+Invoke-EasyPIMAssignmentRenewal -ConfigFilePath .\pim-config-azure.jsonc -TenantId $t -SubscriptionId $s -WhatIf
+Preview which declared, expiring Azure assignments would be extended.
+.EXAMPLE
+Invoke-EasyPIMAssignmentRenewal -ConfigFilePath .\pim-config-azure.jsonc -TenantId $t -SubscriptionId $s
+Extend all declared Azure assignments expiring within 14 days.
+.LINK
+https://github.com/kayasax/EasyPIM
+#>
+function Invoke-EasyPIMAssignmentRenewal {
+    [CmdletBinding(DefaultParameterSetName = 'FilePath', SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingWriteHost", "")]
+    param (
+        [Parameter(Mandatory = $true, ParameterSetName = 'FilePath')]
+        [string]$ConfigFilePath,
+        [Parameter(Mandatory = $true, ParameterSetName = 'KeyVault')]
+        [string]$KeyVaultName,
+        [Parameter(Mandatory = $true, ParameterSetName = 'KeyVault')]
+        [string]$SecretName,
+        [Parameter()][string]$TenantId,
+        [Parameter()][string]$SubscriptionId,
+        [Parameter()][ValidateRange(1, 365)][int]$ThresholdDays = 14
+    )
+
+    Write-SectionHeader -Message "EasyPIM Assignment Renewal (threshold: $ThresholdDays days)"
+
+    if (-not $TenantId) { $TenantId = $env:tenantid }
+    if (-not $SubscriptionId) { $SubscriptionId = $env:subscriptionid }
+
+    $summary = [pscustomobject]@{
+        FoundExpiring = 0
+        Extended      = 0
+        Skipped       = 0
+        Details       = @()
+    }
+
+    # 1. Load + normalize config
+    $config = if ($PSCmdlet.ParameterSetName -eq 'KeyVault') {
+        Get-EasyPIMConfiguration -KeyVaultName $KeyVaultName -SecretName $SecretName
+    } else {
+        Get-EasyPIMConfiguration -ConfigFilePath $ConfigFilePath
+    }
+    $processed = Initialize-EasyPIMAssignments -Config $config
+
+    if (-not $processed.Assignments -or -not ($processed.Assignments.PSObject.Properties.Name -contains 'AzureRoles') -or -not $processed.Assignments.AzureRoles) {
+        Write-Host "No Azure role assignments declared in configuration; nothing to renew." -ForegroundColor Yellow
+        return $summary
+    }
+
+    $now = (Get-Date).ToUniversalTime()
+    $cutoff = $now.AddDays($ThresholdDays)
+
+    foreach ($roleBlock in $processed.Assignments.AzureRoles) {
+        $roleName = $roleBlock.RoleName; if (-not $roleName) { $roleName = $roleBlock.roleName }
+        $scope    = $roleBlock.Scope;    if (-not $scope)    { $scope = $roleBlock.scope }
+        if (-not $roleName -or -not $scope) { continue }
+
+        # Pre-fetch live assignments once per scope
+        $liveEligible = @()
+        $liveActive   = @()
+        try { $liveEligible = @(Get-PIMAzureResourceEligibleAssignment -tenantID $TenantId -subscriptionID $SubscriptionId -scope $scope -ErrorAction SilentlyContinue) } catch { Write-Verbose "[Renewal] eligible fetch failed for ${scope}: $($_.Exception.Message)" }
+        try { $liveActive   = @(Get-PIMAzureResourceActiveAssignment   -tenantID $TenantId -subscriptionID $SubscriptionId -scope $scope -ErrorAction SilentlyContinue) } catch { Write-Verbose "[Renewal] active fetch failed for ${scope}: $($_.Exception.Message)" }
+
+        # Read policy once per role/scope
+        $policy = $null
+        try { $policy = Get-PIMAzureResourcePolicy -tenantID $TenantId -scope $scope -rolename $roleName } catch { Write-Verbose "[Renewal] policy fetch failed for $roleName@${scope}: $($_.Exception.Message)" }
+
+        foreach ($a in ($roleBlock.assignments | Where-Object { $_ })) {
+            $principalId = $a.principalId
+            $isActive = ($a.assignmentType -match 'Active')
+
+            # Match against live assignments of the same kind
+            $liveSet = if ($isActive) { $liveActive } else { $liveEligible }
+            $match = $liveSet | Where-Object {
+                $_.PrincipalId -eq $principalId -and $_.RoleName -eq $roleName -and $_.ScopeId -eq $scope
+            } | Select-Object -First 1
+            if (-not $match) { continue }  # declared but not currently live -> New-EasyPIMAssignments handles creation, not us
+
+            # Skip permanent / not-expiring
+            if ($match.endDateTime -eq 'permanent' -or [string]::IsNullOrWhiteSpace($match.endDateTime)) { continue }
+            $end = $null
+            try { $end = [datetime]::Parse($match.endDateTime).ToUniversalTime() } catch { continue }
+            if ($end -gt $cutoff) { continue }
+
+            $summary.FoundExpiring++
+            $ctx = "Azure/$roleName@$scope/$principalId [$($a.assignmentType)]"
+
+            # Compute new end date from policy max
+            $maxDurationIso = if ($isActive) { $policy.MaximumActiveAssignmentDuration } else { $policy.MaximumEligibleAssignmentDuration }
+            $allowPermanent = if ($isActive) { $policy.AllowPermanentActiveAssignment } else { $policy.AllowPermanentEligibleAssignment }
+
+            if ([string]::IsNullOrWhiteSpace($maxDurationIso)) {
+                $reason = if ("$allowPermanent" -eq 'true') { "policy allows permanent (no max duration) - consider a permanent assignment to remove the need to extend" } else { "no maximum duration in policy" }
+                Write-Host "  SKIP  $ctx : $reason" -ForegroundColor Yellow
+                $summary.Skipped++
+                $summary.Details += [pscustomobject]@{ Context = $ctx; Action = 'Skipped'; Reason = $reason }
+                continue
+            }
+
+            $maxTs = $null
+            try { $maxTs = [System.Xml.XmlConvert]::ToTimeSpan($maxDurationIso) } catch { }
+            if ($null -eq $maxTs) {
+                Write-Host "  SKIP  $ctx : could not parse policy max duration '$maxDurationIso'" -ForegroundColor Yellow
+                $summary.Skipped++
+                $summary.Details += [pscustomobject]@{ Context = $ctx; Action = 'Skipped'; Reason = "unparsable max duration '$maxDurationIso'" }
+                continue
+            }
+            $newEnd = ($now.Add($maxTs)).ToString("yyyy-MM-ddTHH:mm:ssZ")
+            if ("$allowPermanent" -eq 'true') {
+                Write-Host "  NOTE  $ctx : policy allows permanent; extending to policy max ($maxDurationIso). A permanent assignment would remove the need to extend." -ForegroundColor DarkCyan
+            }
+
+            if ($WhatIfPreference) {
+                Write-Host "  What if: Extend $ctx to $newEnd" -ForegroundColor Cyan
+                $summary.Details += [pscustomobject]@{ Context = $ctx; Action = 'PlannedExtend'; NewEnd = $newEnd }
+                continue
+            }
+
+            $params = @{
+                tenantID       = $TenantId
+                subscriptionID = $SubscriptionId
+                scope          = $scope
+                rolename       = $roleName
+                principalID    = $principalId
+                newEndDateTime = $newEnd
+            }
+            try {
+                if ($isActive) { Update-PIMAzureResourceActiveAssignment @params }
+                else           { Update-PIMAzureResourceEligibleAssignment @params }
+                Write-Host "  EXTENDED  $ctx -> $newEnd" -ForegroundColor Green
+                $summary.Extended++
+                $summary.Details += [pscustomobject]@{ Context = $ctx; Action = 'Extended'; NewEnd = $newEnd }
+            } catch {
+                Write-Host "  FAILED  $ctx : $($_.Exception.Message)" -ForegroundColor Red
+                $summary.Skipped++
+                $summary.Details += [pscustomobject]@{ Context = $ctx; Action = 'Failed'; Reason = $_.Exception.Message }
+            }
+        }
+    }
+
+    Write-Host ""
+    Write-Host "Renewal summary: FoundExpiring=$($summary.FoundExpiring) Extended=$($summary.Extended) Skipped=$($summary.Skipped)" -ForegroundColor Cyan
+    return $summary
+}

--- a/EasyPIM/Documentation/Invoke-EasyPIMAssignmentRenewal.md
+++ b/EasyPIM/Documentation/Invoke-EasyPIMAssignmentRenewal.md
@@ -9,6 +9,9 @@ request type, which requires no approval, so it can run unattended in a pipeline
 - **v1 supports Azure resource roles only.** Entra directory roles and PIM-for-Groups are not yet supported.
 - Only assignments **declared in the configuration** are extended. Live assignments not present in the
   configuration are never touched.
+- Matching is by exact scope. An assignment **inherited** from a higher scope (for example, a management
+  group) whose configured scope is a child subscription is treated as not-live at the configured scope and
+  is skipped. Declare the assignment at the scope where it actually exists to have it renewed.
 
 ## Parameters
 

--- a/EasyPIM/Documentation/Invoke-EasyPIMAssignmentRenewal.md
+++ b/EasyPIM/Documentation/Invoke-EasyPIMAssignmentRenewal.md
@@ -1,0 +1,48 @@
+# Invoke-EasyPIMAssignmentRenewal
+
+Proactively extends Azure resource role PIM assignments (eligible and active) that are declared in an EasyPIM
+orchestrator configuration and are expiring within a threshold (default 14 days). Uses the ARM `AdminExtend`
+request type, which requires no approval, so it can run unattended in a pipeline or runbook.
+
+## Scope
+
+- **v1 supports Azure resource roles only.** Entra directory roles and PIM-for-Groups are not yet supported.
+- Only assignments **declared in the configuration** are extended. Live assignments not present in the
+  configuration are never touched.
+
+## Parameters
+
+| Parameter | Description |
+| --- | --- |
+| `ConfigFilePath` | Path to the JSON/JSONC orchestrator configuration file. |
+| `KeyVaultName` / `SecretName` | Load the configuration from a Key Vault secret instead of a file. |
+| `TenantId` | Target tenant GUID. Falls back to `$env:tenantid`. |
+| `SubscriptionId` | Target subscription GUID. Falls back to `$env:subscriptionid`. |
+| `ThresholdDays` | Extend assignments expiring within this many days. Default `14`. |
+
+## Behaviour
+
+- The new end date is `now + policy maximum assignment duration`, clamped to the role policy.
+- If a role policy allows permanent assignment but has no maximum duration, the assignment is skipped with a
+  note recommending a permanent assignment instead.
+- Idempotent: an assignment already extended past the threshold is not a candidate, and the core cmdlets skip a
+  submission when an `AdminExtend` request for the same schedule is already in flight.
+- Supports `-WhatIf` and returns a summary object (`FoundExpiring`, `Extended`, `Skipped`, `Details`).
+
+## Examples
+
+```powershell
+# Preview
+Invoke-EasyPIMAssignmentRenewal -ConfigFilePath .\pim-config-azure.jsonc -TenantId $t -SubscriptionId $s -WhatIf
+
+# Apply
+Invoke-EasyPIMAssignmentRenewal -ConfigFilePath .\pim-config-azure.jsonc -TenantId $t -SubscriptionId $s
+
+# Weekly unattended run (scheduled task / runbook)
+Invoke-EasyPIMAssignmentRenewal -KeyVaultName kv-easypim -SecretName pim-config -TenantId $t -SubscriptionId $s
+```
+
+## See also
+
+- <https://github.com/kayasax/EasyPIM>
+- <https://learn.microsoft.com/azure/templates/microsoft.authorization/roleeligibilityschedulerequests>

--- a/EasyPIM/EasyPIM.psd1
+++ b/EasyPIM/EasyPIM.psd1
@@ -6,7 +6,7 @@
 RootModule = 'EasyPIM.psm1'
 
 # Version number of this module.
-ModuleVersion = '2.3.1'
+ModuleVersion = '2.4.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/EasyPIM/EasyPIM.psd1
+++ b/EasyPIM/EasyPIM.psd1
@@ -53,6 +53,7 @@ FunctionsToExport = @(
     "Get-PIMAzureResourceEligibleAssignment",
     "New-PIMAzureResourceActiveAssignment",
     "New-PIMAzureResourceEligibleAssignment",
+    "Update-PIMAzureResourceEligibleAssignment",
     "Remove-PIMAzureResourceEligibleAssignment",
     "Remove-PIMAzureResourceActiveAssignment",
     "Get-PIMEntraRolePolicy",

--- a/EasyPIM/EasyPIM.psd1
+++ b/EasyPIM/EasyPIM.psd1
@@ -54,6 +54,7 @@ FunctionsToExport = @(
     "New-PIMAzureResourceActiveAssignment",
     "New-PIMAzureResourceEligibleAssignment",
     "Update-PIMAzureResourceEligibleAssignment",
+    "Update-PIMAzureResourceActiveAssignment",
     "Remove-PIMAzureResourceEligibleAssignment",
     "Remove-PIMAzureResourceActiveAssignment",
     "Get-PIMEntraRolePolicy",

--- a/EasyPIM/EasyPIM.psm1
+++ b/EasyPIM/EasyPIM.psm1
@@ -25,6 +25,7 @@ Export-ModuleMember -Function @(
     'Get-PIMAzureResourceEligibleAssignment',
     'New-PIMAzureResourceActiveAssignment',
     'New-PIMAzureResourceEligibleAssignment',
+    'Update-PIMAzureResourceEligibleAssignment',
     'Remove-PIMAzureResourceEligibleAssignment',
     'Remove-PIMAzureResourceActiveAssignment',
     'Get-PIMEntraRolePolicy',

--- a/EasyPIM/EasyPIM.psm1
+++ b/EasyPIM/EasyPIM.psm1
@@ -26,6 +26,7 @@ Export-ModuleMember -Function @(
     'New-PIMAzureResourceActiveAssignment',
     'New-PIMAzureResourceEligibleAssignment',
     'Update-PIMAzureResourceEligibleAssignment',
+    'Update-PIMAzureResourceActiveAssignment',
     'Remove-PIMAzureResourceEligibleAssignment',
     'Remove-PIMAzureResourceActiveAssignment',
     'Get-PIMEntraRolePolicy',

--- a/EasyPIM/functions/Update-PIMAzureResourceActiveAssignment.ps1
+++ b/EasyPIM/functions/Update-PIMAzureResourceActiveAssignment.ps1
@@ -1,0 +1,119 @@
+<#
+    .Synopsis
+    Extend (AdminExtend) an existing, still-valid active Azure resource role assignment that is about to expire.
+    .Description
+    Submits an ARM roleAssignmentScheduleRequests request with requestType 'AdminExtend', pushing the assignment's
+    end date out to -newEndDateTime. Admin-initiated extension requires no approval. Note: this prolongs standing
+    (already-granted) access; prefer extending eligible assignments where possible.
+    .Parameter tenantID
+    EntraID tenant ID
+    .Parameter subscriptionID
+    Subscription ID (used to build the scope when -scope is not supplied)
+    .Parameter scope
+    Use scope if you want to target a scope other than the subscription
+    .Parameter principalID
+    ObjectID of the principal whose assignment is extended
+    .Parameter rolename
+    Name of the role whose active assignment is extended
+    .Parameter newEndDateTime
+    The new expiration date/time for the assignment. Parsed and sent as UTC.
+    .Parameter justification
+    Justification (auto-generated if not provided)
+    .Example
+    PS> Update-PIMAzureResourceActiveAssignment -tenantID $t -subscriptionID $s -rolename "Reader" -principalID $p -newEndDateTime "2026-12-31"
+    .Link
+    https://learn.microsoft.com/azure/templates/microsoft.authorization/roleassignmentschedulerequests
+    .Notes
+    Author: EasyPIM contributors
+    Homepage: https://github.com/kayasax/EasyPIM
+#>
+function Update-PIMAzureResourceActiveAssignment {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingWriteHost", "")]
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    param (
+        [Parameter(Mandatory = $true)][String]$tenantID,
+        [Parameter()][String]$subscriptionID,
+        [Parameter()][String]$scope,
+        [Parameter(Mandatory = $true)][String]$principalID,
+        [Parameter(Mandatory = $true)][String]$rolename,
+        [Parameter(Mandatory = $true)][String]$newEndDateTime,
+        [Parameter()][String]$justification
+    )
+
+    try {
+        if (-not $PSBoundParameters.Keys.Contains('scope')) {
+            if (-not $PSBoundParameters.Keys.Contains('subscriptionID')) {
+                throw "ERROR : You must provide a subscription ID or a scope, exiting."
+            }
+            $scope = "/subscriptions/$subscriptionID"
+        }
+        $script:tenantID = $tenantID
+
+        $ARMhost = Get-PIMAzureEnvironmentEndpoint -EndpointType 'ARM'
+        $ARMendpoint = "$($ARMhost.TrimEnd('/'))/$($scope.TrimStart('/'))/providers/Microsoft.Authorization"
+
+        $restUri = "$ARMendpoint/roleDefinitions?api-version=2022-04-01&`$filter=roleName eq '$rolename'"
+        $roleResponse = Invoke-ARM -restURI $restUri -method "get" -body $null
+        $roleID = ($roleResponse.value | Select-Object -First 1).id
+        if (-not $roleID) { throw "ERROR : Role '$rolename' not found at scope $scope." }
+
+        $newEnd = Get-Date ([datetime]::Parse($newEndDateTime)).ToUniversalTime() -Format "yyyy-MM-ddTHH:mm:ssZ"
+
+        $schedUri = "$ARMendpoint/roleAssignmentSchedules?api-version=2020-10-01-preview&`$filter=assignedTo('$principalID')"
+        $schedResponse = Invoke-ARM -restURI $schedUri -method "get" -body $null
+        $targetSchedule = $schedResponse.value | Where-Object {
+            $_.properties.roleDefinitionId -eq $roleID -and $_.properties.scope -eq $scope
+        } | Select-Object -First 1
+        if (-not $targetSchedule) {
+            throw "ERROR : No active assignment found for principal $principalID role '$rolename' at scope $scope to extend."
+        }
+        $targetScheduleId = $targetSchedule.id
+
+        $reqListUri = "$ARMendpoint/roleAssignmentScheduleRequests?api-version=2020-10-01&`$filter=principalId eq '$principalID'"
+        $reqList = Invoke-ARM -restURI $reqListUri -method "get" -body $null
+        $inFlight = $reqList.value | Where-Object {
+            $_.properties.targetRoleAssignmentScheduleId -eq $targetScheduleId -and
+            $_.properties.requestType -eq 'AdminExtend' -and
+            $_.properties.status -match 'Pending|Accepted|Granted'
+        }
+        if ($inFlight) {
+            Write-Warning "An AdminExtend request is already pending for role '$rolename' principal $principalID at scope $scope. Skipping."
+            return
+        }
+
+        if (-not $PSBoundParameters.Keys.Contains('justification')) {
+            $justification = "Extended by EasyPIM by $($(Get-AzContext).account)"
+        }
+
+        $body = @"
+{
+    "properties": {
+        "principalId": "$principalID",
+        "roleDefinitionId": "$roleID",
+        "requestType": "AdminExtend",
+        "justification": "$justification",
+        "targetRoleAssignmentScheduleId": "$targetScheduleId",
+        "scheduleInfo": {
+            "expiration": {
+                "type": "AfterDateTime",
+                "endDateTime": "$newEnd"
+            }
+        }
+    }
+}
+"@
+
+        $guid = New-Guid
+        $putUri = "$ARMendpoint/roleAssignmentScheduleRequests/$($guid)?api-version=2020-10-01"
+
+        if ($PSCmdlet.ShouldProcess("$rolename / $principalID @ $scope", "Extend active assignment to $newEnd")) {
+            Write-Verbose "Sending AdminExtend PUT at $putUri with body:`n$body"
+            $response = Invoke-ARM -restURI $putUri -method PUT -body $body -Verbose:$false
+            Write-Host "SUCCESS : Active assignment extended to $newEnd"
+            return $response
+        }
+    }
+    catch {
+        Mycatch $_
+    }
+}

--- a/EasyPIM/functions/Update-PIMAzureResourceEligibleAssignment.ps1
+++ b/EasyPIM/functions/Update-PIMAzureResourceEligibleAssignment.ps1
@@ -58,7 +58,7 @@ function Update-PIMAzureResourceEligibleAssignment {
         # 1. Resolve role definition id
         $restUri = "$ARMendpoint/roleDefinitions?api-version=2022-04-01&`$filter=roleName eq '$rolename'"
         $roleResponse = Invoke-ARM -restURI $restUri -method "get" -body $null
-        $roleID = $roleResponse.value.id
+        $roleID = ($roleResponse.value | Select-Object -First 1).id
         if (-not $roleID) { throw "ERROR : Role '$rolename' not found at scope $scope." }
         Write-Verbose "Resolved role '$rolename' to $roleID"
 
@@ -70,7 +70,7 @@ function Update-PIMAzureResourceEligibleAssignment {
         $schedUri = "$ARMendpoint/roleEligibilitySchedules?api-version=2020-10-01-preview&`$filter=assignedTo('$principalID')"
         $schedResponse = Invoke-ARM -restURI $schedUri -method "get" -body $null
         $targetSchedule = $schedResponse.value | Where-Object {
-            $_.properties.roleDefinitionId -eq $roleID -and $_.properties.scope.id -eq $scope
+            $_.properties.roleDefinitionId -eq $roleID -and $_.properties.scope -eq $scope
         } | Select-Object -First 1
         if (-not $targetSchedule) {
             throw "ERROR : No eligible assignment found for principal $principalID role '$rolename' at scope $scope to extend."

--- a/EasyPIM/functions/Update-PIMAzureResourceEligibleAssignment.ps1
+++ b/EasyPIM/functions/Update-PIMAzureResourceEligibleAssignment.ps1
@@ -1,0 +1,130 @@
+<#
+    .Synopsis
+    Extend (AdminExtend) an existing, still-valid eligible Azure resource role assignment that is about to expire.
+    .Description
+    Submits an ARM roleEligibilityScheduleRequests request with requestType 'AdminExtend', pushing the assignment's
+    end date out to -newEndDateTime. Admin-initiated extension requires no approval; it only notifies other admins.
+    Use this to renew time-bound eligibility before it lapses (as opposed to AdminRenew, which reactivates an
+    already-expired assignment). The target schedule is resolved from the principal's existing eligible schedules.
+    .Parameter tenantID
+    EntraID tenant ID
+    .Parameter subscriptionID
+    Subscription ID (used to build the scope when -scope is not supplied)
+    .Parameter scope
+    Use scope if you want to target a scope other than the subscription
+    .Parameter principalID
+    ObjectID of the principal (user, group or service principal) whose assignment is extended
+    .Parameter rolename
+    Name of the role whose eligible assignment is extended
+    .Parameter newEndDateTime
+    The new expiration date/time for the assignment. Parsed and sent as UTC.
+    .Parameter justification
+    Justification (auto-generated if not provided)
+    .Example
+    PS> Update-PIMAzureResourceEligibleAssignment -tenantID $t -subscriptionID $s -rolename "Reader" -principalID $p -newEndDateTime "2026-12-31"
+
+    Extend the Reader eligible assignment for the principal to the end of 2026.
+    .Link
+    https://learn.microsoft.com/azure/templates/microsoft.authorization/roleeligibilityschedulerequests
+    .Notes
+    Author: EasyPIM contributors
+    Homepage: https://github.com/kayasax/EasyPIM
+#>
+function Update-PIMAzureResourceEligibleAssignment {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingWriteHost", "")]
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    param (
+        [Parameter(Mandatory = $true)][String]$tenantID,
+        [Parameter()][String]$subscriptionID,
+        [Parameter()][String]$scope,
+        [Parameter(Mandatory = $true)][String]$principalID,
+        [Parameter(Mandatory = $true)][String]$rolename,
+        [Parameter(Mandatory = $true)][String]$newEndDateTime,
+        [Parameter()][String]$justification
+    )
+
+    try {
+        if (-not $PSBoundParameters.Keys.Contains('scope')) {
+            if (-not $PSBoundParameters.Keys.Contains('subscriptionID')) {
+                throw "ERROR : You must provide a subscription ID or a scope, exiting."
+            }
+            $scope = "/subscriptions/$subscriptionID"
+        }
+        $script:tenantID = $tenantID
+
+        $ARMhost = Get-PIMAzureEnvironmentEndpoint -EndpointType 'ARM'
+        $ARMendpoint = "$($ARMhost.TrimEnd('/'))/$($scope.TrimStart('/'))/providers/Microsoft.Authorization"
+
+        # 1. Resolve role definition id
+        $restUri = "$ARMendpoint/roleDefinitions?api-version=2022-04-01&`$filter=roleName eq '$rolename'"
+        $roleResponse = Invoke-ARM -restURI $restUri -method "get" -body $null
+        $roleID = $roleResponse.value.id
+        if (-not $roleID) { throw "ERROR : Role '$rolename' not found at scope $scope." }
+        Write-Verbose "Resolved role '$rolename' to $roleID"
+
+        # 2. Normalize new end date to UTC ISO 8601 with trailing Z
+        $newEnd = Get-Date ([datetime]::Parse($newEndDateTime)).ToUniversalTime() -Format "yyyy-MM-ddTHH:mm:ssZ"
+        Write-Verbose "New end date (UTC): $newEnd"
+
+        # 3. Find the target eligibility schedule id for this principal + role + scope
+        $schedUri = "$ARMendpoint/roleEligibilitySchedules?api-version=2020-10-01-preview&`$filter=assignedTo('$principalID')"
+        $schedResponse = Invoke-ARM -restURI $schedUri -method "get" -body $null
+        $targetSchedule = $schedResponse.value | Where-Object {
+            $_.properties.roleDefinitionId -eq $roleID -and $_.properties.scope.id -eq $scope
+        } | Select-Object -First 1
+        if (-not $targetSchedule) {
+            throw "ERROR : No eligible assignment found for principal $principalID role '$rolename' at scope $scope to extend."
+        }
+        $targetScheduleId = $targetSchedule.id
+        Write-Verbose "Target eligibility schedule id: $targetScheduleId"
+
+        # 4. Idempotency: skip if an AdminExtend request for this schedule is already in flight
+        $reqListUri = "$ARMendpoint/roleEligibilityScheduleRequests?api-version=2020-10-01&`$filter=principalId eq '$principalID'"
+        $reqList = Invoke-ARM -restURI $reqListUri -method "get" -body $null
+        $inFlight = $reqList.value | Where-Object {
+            $_.properties.targetRoleEligibilityScheduleId -eq $targetScheduleId -and
+            $_.properties.requestType -eq 'AdminExtend' -and
+            $_.properties.status -match 'Pending|Accepted|Granted'
+        }
+        if ($inFlight) {
+            Write-Warning "An AdminExtend request is already pending for role '$rolename' principal $principalID at scope $scope. Skipping."
+            return
+        }
+
+        if (-not $PSBoundParameters.Keys.Contains('justification')) {
+            $justification = "Extended by EasyPIM by $($(Get-AzContext).account)"
+        }
+
+        # 5. Build and submit the AdminExtend request
+        $body = @"
+{
+    "properties": {
+        "principalId": "$principalID",
+        "roleDefinitionId": "$roleID",
+        "requestType": "AdminExtend",
+        "justification": "$justification",
+        "targetRoleEligibilityScheduleId": "$targetScheduleId",
+        "scheduleInfo": {
+            "expiration": {
+                "type": "AfterDateTime",
+                "endDateTime": "$newEnd"
+            }
+        }
+    }
+}
+"@
+
+        $guid = New-Guid
+        $putUri = "$ARMendpoint/roleEligibilityScheduleRequests/$($guid)?api-version=2020-10-01"
+
+        if ($PSCmdlet.ShouldProcess("$rolename / $principalID @ $scope", "Extend eligible assignment to $newEnd")) {
+            Write-Verbose "Sending AdminExtend PUT at $putUri with body:`n$body"
+            $response = Invoke-ARM -restURI $putUri -method PUT -body $body -Verbose:$false
+            Write-Host "SUCCESS : Eligible assignment extended to $newEnd"
+            return $response
+        }
+    }
+    catch {
+        Mycatch $_
+    }
+}

--- a/tests/functions/Update-PIMAzureResourceActiveAssignment.Tests.ps1
+++ b/tests/functions/Update-PIMAzureResourceActiveAssignment.Tests.ps1
@@ -1,0 +1,59 @@
+$ModulePath = Join-Path $PSScriptRoot "..\..\EasyPIM\EasyPIM.psd1"
+Import-Module $ModulePath -Force
+
+Describe "Update-PIMAzureResourceActiveAssignment - AdminExtend" -Tag 'Unit' {
+
+    BeforeEach {
+        $script:capturedBody = $null
+        $script:capturedUri  = $null
+
+        Mock -ModuleName EasyPIM Get-PIMAzureEnvironmentEndpoint { return "https://management.azure.com" }
+        Mock -ModuleName EasyPIM Get-AzContext { return [PSCustomObject]@{ Account = "admin@contoso.com" } }
+
+        Mock -ModuleName EasyPIM Invoke-ARM {
+            param($restURI, $method, $body)
+            if ($restURI -match "roleDefinitions") {
+                return [PSCustomObject]@{ value = @(
+                    [PSCustomObject]@{ id = "/subscriptions/sub1/providers/Microsoft.Authorization/roleDefinitions/role-guid" }
+                ) }
+            }
+            if ($restURI -match "roleAssignmentSchedules\?") {
+                return [PSCustomObject]@{ value = @(
+                    [PSCustomObject]@{
+                        id = "/subscriptions/sub1/providers/Microsoft.Authorization/roleAssignmentSchedules/sched-guid"
+                        properties = [PSCustomObject]@{
+                            roleDefinitionId = "/subscriptions/sub1/providers/Microsoft.Authorization/roleDefinitions/role-guid"
+                            scope = "/subscriptions/sub1"
+                            principalId = "11111111-1111-1111-1111-111111111111"
+                        }
+                    }
+                ) }
+            }
+            if ($restURI -match "roleAssignmentScheduleRequests\?") { return [PSCustomObject]@{ value = @() } }
+            $script:capturedUri  = $restURI
+            $script:capturedBody = $body
+            return [PSCustomObject]@{ properties = [PSCustomObject]@{} }
+        }
+    }
+
+    It "Submits an AdminExtend request with the target role assignment schedule id" {
+        Update-PIMAzureResourceActiveAssignment `
+            -tenantID "00000000-0000-0000-0000-000000000000" -subscriptionID "sub1" `
+            -rolename "Reader" -principalID "11111111-1111-1111-1111-111111111111" `
+            -newEndDateTime "2026-12-31T00:00:00Z"
+
+        $script:capturedUri  | Should -Match "roleAssignmentScheduleRequests/"
+        $script:capturedBody | Should -Match '"requestType":\s*"AdminExtend"'
+        $script:capturedBody | Should -Match '"targetRoleAssignmentScheduleId":\s*".*sched-guid"'
+        $script:capturedBody | Should -Match '"type":\s*"AfterDateTime"'
+    }
+
+    It "Does not submit a request under -WhatIf" {
+        Update-PIMAzureResourceActiveAssignment `
+            -tenantID "00000000-0000-0000-0000-000000000000" -subscriptionID "sub1" `
+            -rolename "Reader" -principalID "11111111-1111-1111-1111-111111111111" `
+            -newEndDateTime "2026-12-31T00:00:00Z" -WhatIf
+
+        $script:capturedBody | Should -BeNullOrEmpty
+    }
+}

--- a/tests/functions/Update-PIMAzureResourceEligibleAssignment.Tests.ps1
+++ b/tests/functions/Update-PIMAzureResourceEligibleAssignment.Tests.ps1
@@ -24,7 +24,7 @@ Describe "Update-PIMAzureResourceEligibleAssignment - AdminExtend" -Tag 'Unit' {
                         id = "/subscriptions/sub1/providers/Microsoft.Authorization/roleEligibilitySchedules/sched-guid"
                         properties = [PSCustomObject]@{
                             roleDefinitionId = "/subscriptions/sub1/providers/Microsoft.Authorization/roleDefinitions/role-guid"
-                            scope = [PSCustomObject]@{ id = "/subscriptions/sub1" }
+                            scope = "/subscriptions/sub1"
                             principalId = "11111111-1111-1111-1111-111111111111"
                         }
                     }
@@ -82,5 +82,42 @@ Describe "Update-PIMAzureResourceEligibleAssignment - AdminExtend" -Tag 'Unit' {
             -tenantID "00000000-0000-0000-0000-000000000000" -subscriptionID "sub1" `
             -rolename "Reader" -principalID "11111111-1111-1111-1111-111111111111" `
             -newEndDateTime "2026-12-31T00:00:00Z" -ErrorAction Stop } | Should -Throw
+    }
+
+    It "Skips submission when an AdminExtend request is already in flight" {
+        Mock -ModuleName EasyPIM Invoke-ARM {
+            param($restURI, $method, $body)
+            if ($restURI -match "roleDefinitions") {
+                return [PSCustomObject]@{ value = @([PSCustomObject]@{ id = "/subscriptions/sub1/providers/Microsoft.Authorization/roleDefinitions/role-guid" }) }
+            }
+            if ($restURI -match "roleEligibilitySchedules\?") {
+                return [PSCustomObject]@{ value = @([PSCustomObject]@{
+                    id = "/subscriptions/sub1/providers/Microsoft.Authorization/roleEligibilitySchedules/sched-guid"
+                    properties = [PSCustomObject]@{
+                        roleDefinitionId = "/subscriptions/sub1/providers/Microsoft.Authorization/roleDefinitions/role-guid"
+                        scope = "/subscriptions/sub1"
+                        principalId = "11111111-1111-1111-1111-111111111111"
+                    }
+                }) }
+            }
+            if ($restURI -match "roleEligibilityScheduleRequests\?") {
+                return [PSCustomObject]@{ value = @([PSCustomObject]@{
+                    properties = [PSCustomObject]@{
+                        targetRoleEligibilityScheduleId = "/subscriptions/sub1/providers/Microsoft.Authorization/roleEligibilitySchedules/sched-guid"
+                        requestType = "AdminExtend"
+                        status = "PendingApproval"
+                    }
+                }) }
+            }
+            $script:capturedBody = $body
+            return [PSCustomObject]@{ properties = [PSCustomObject]@{} }
+        }
+
+        Update-PIMAzureResourceEligibleAssignment `
+            -tenantID "00000000-0000-0000-0000-000000000000" -subscriptionID "sub1" `
+            -rolename "Reader" -principalID "11111111-1111-1111-1111-111111111111" `
+            -newEndDateTime "2026-12-31T00:00:00Z" -WarningAction SilentlyContinue
+
+        $script:capturedBody | Should -BeNullOrEmpty
     }
 }

--- a/tests/functions/Update-PIMAzureResourceEligibleAssignment.Tests.ps1
+++ b/tests/functions/Update-PIMAzureResourceEligibleAssignment.Tests.ps1
@@ -1,0 +1,86 @@
+$ModulePath = Join-Path $PSScriptRoot "..\..\EasyPIM\EasyPIM.psd1"
+Import-Module $ModulePath -Force
+
+Describe "Update-PIMAzureResourceEligibleAssignment - AdminExtend" -Tag 'Unit' {
+
+    BeforeEach {
+        $script:capturedBody = $null
+        $script:capturedUri  = $null
+
+        Mock -ModuleName EasyPIM Get-PIMAzureEnvironmentEndpoint { return "https://management.azure.com" }
+
+        Mock -ModuleName EasyPIM Get-AzContext { return [PSCustomObject]@{ Account = "admin@contoso.com" } }
+
+        Mock -ModuleName EasyPIM Invoke-ARM {
+            param($restURI, $method, $body)
+            if ($restURI -match "roleDefinitions") {
+                return [PSCustomObject]@{ value = @(
+                    [PSCustomObject]@{ id = "/subscriptions/sub1/providers/Microsoft.Authorization/roleDefinitions/role-guid" }
+                ) }
+            }
+            if ($restURI -match "roleEligibilitySchedules\?") {
+                return [PSCustomObject]@{ value = @(
+                    [PSCustomObject]@{
+                        id = "/subscriptions/sub1/providers/Microsoft.Authorization/roleEligibilitySchedules/sched-guid"
+                        properties = [PSCustomObject]@{
+                            roleDefinitionId = "/subscriptions/sub1/providers/Microsoft.Authorization/roleDefinitions/role-guid"
+                            scope = [PSCustomObject]@{ id = "/subscriptions/sub1" }
+                            principalId = "11111111-1111-1111-1111-111111111111"
+                        }
+                    }
+                ) }
+            }
+            if ($restURI -match "roleEligibilityScheduleRequests\?") {
+                # pending-check list: none in flight
+                return [PSCustomObject]@{ value = @() }
+            }
+            # PUT the extend request
+            $script:capturedUri  = $restURI
+            $script:capturedBody = $body
+            return [PSCustomObject]@{ properties = [PSCustomObject]@{} }
+        }
+    }
+
+    It "Submits an AdminExtend request with the target schedule id and AfterDateTime end date" {
+        Update-PIMAzureResourceEligibleAssignment `
+            -tenantID       "00000000-0000-0000-0000-000000000000" `
+            -subscriptionID "sub1" `
+            -rolename       "Reader" `
+            -principalID    "11111111-1111-1111-1111-111111111111" `
+            -newEndDateTime "2026-12-31T00:00:00Z"
+
+        $script:capturedUri  | Should -Match "roleEligibilityScheduleRequests/"
+        $script:capturedBody | Should -Match '"requestType":\s*"AdminExtend"'
+        $script:capturedBody | Should -Match '"targetRoleEligibilityScheduleId":\s*".*sched-guid"'
+        $script:capturedBody | Should -Match '"type":\s*"AfterDateTime"'
+        $script:capturedBody | Should -Match '2026-12-31T00:00:00Z'
+    }
+
+    It "Does not submit a request under -WhatIf" {
+        Update-PIMAzureResourceEligibleAssignment `
+            -tenantID       "00000000-0000-0000-0000-000000000000" `
+            -subscriptionID "sub1" `
+            -rolename       "Reader" `
+            -principalID    "11111111-1111-1111-1111-111111111111" `
+            -newEndDateTime "2026-12-31T00:00:00Z" `
+            -WhatIf
+
+        $script:capturedBody | Should -BeNullOrEmpty
+    }
+
+    It "Throws when no matching eligible schedule exists" {
+        Mock -ModuleName EasyPIM Invoke-ARM {
+            param($restURI, $method, $body)
+            if ($restURI -match "roleDefinitions") {
+                return [PSCustomObject]@{ value = @([PSCustomObject]@{ id = "/subscriptions/sub1/providers/Microsoft.Authorization/roleDefinitions/role-guid" }) }
+            }
+            if ($restURI -match "roleEligibilitySchedules\?") { return [PSCustomObject]@{ value = @() } }
+            return [PSCustomObject]@{ value = @() }
+        }
+
+        { Update-PIMAzureResourceEligibleAssignment `
+            -tenantID "00000000-0000-0000-0000-000000000000" -subscriptionID "sub1" `
+            -rolename "Reader" -principalID "11111111-1111-1111-1111-111111111111" `
+            -newEndDateTime "2026-12-31T00:00:00Z" -ErrorAction Stop } | Should -Throw
+    }
+}

--- a/tests/orchestrator/Invoke-EasyPIMAssignmentRenewal.Tests.ps1
+++ b/tests/orchestrator/Invoke-EasyPIMAssignmentRenewal.Tests.ps1
@@ -110,4 +110,40 @@ Describe "Invoke-EasyPIMAssignmentRenewal" -Tag 'Unit' {
         $script:extendCalls.Count | Should -Be 0
         $result.FoundExpiring | Should -Be 0
     }
+
+    It "Handles a [datetime] endDateTime under a non-US culture (regression: culture-sensitive parse)" {
+        # The real getters return endDateTime as a [datetime] (ConvertFrom-Json coerces the ISO value),
+        # NOT a string. A previous implementation re-parsed it via [datetime]::Parse(<datetime>), which
+        # round-trips through a US-format string and then reparses under the session culture. Under a
+        # dd/MM culture (e.g. nl-NL) that silently threw (day > 12) or mis-dated the value, dropping
+        # real expiring assignments. This test pins the behaviour: a [datetime] with day-of-month > 12,
+        # under nl-NL, must still be found.
+        $originalCulture = [System.Threading.Thread]::CurrentThread.CurrentCulture
+        try {
+            [System.Threading.Thread]::CurrentThread.CurrentCulture = [System.Globalization.CultureInfo]::new('nl-NL')
+
+            $end = (Get-Date).ToUniversalTime().AddDays(100)
+            if ($end.Day -le 12) { $end = $end.AddDays(13) }  # guarantee day-of-month > 12, still < 365 days out
+
+            Mock -ModuleName EasyPIM.Orchestrator Get-PIMAzureResourceEligibleAssignment {
+                return @([PSCustomObject]@{
+                    PrincipalId = "11111111-1111-1111-1111-111111111111"
+                    RoleName    = "Reader"
+                    ScopeId     = "/subscriptions/sub1"
+                    Status      = "Provisioned"
+                    endDateTime = $end   # a real [datetime] object, as the live getter returns
+                    id          = "inst-guid"
+                })
+            }
+
+            $result = Invoke-EasyPIMAssignmentRenewal -ConfigFilePath "dummy.json" `
+                -TenantId "00000000-0000-0000-0000-000000000000" -SubscriptionId "sub1" -ThresholdDays 365
+
+            $result.FoundExpiring | Should -Be 1
+            $script:extendCalls.Count | Should -Be 1
+        }
+        finally {
+            [System.Threading.Thread]::CurrentThread.CurrentCulture = $originalCulture
+        }
+    }
 }

--- a/tests/orchestrator/Invoke-EasyPIMAssignmentRenewal.Tests.ps1
+++ b/tests/orchestrator/Invoke-EasyPIMAssignmentRenewal.Tests.ps1
@@ -23,7 +23,8 @@ Describe "Invoke-EasyPIMAssignmentRenewal" -Tag 'Unit' {
         }
 
         Mock -ModuleName EasyPIM.Orchestrator Get-EasyPIMConfiguration { return $script:cfg }
-        Mock -ModuleName EasyPIM.Orchestrator Initialize-EasyPIMAssignments { param($Config) return $script:cfg }
+        # Intentionally NOT mocking Initialize-EasyPIMAssignments: the real normalizer must run
+        # so the function exercises the normalized flat arrays ($processed.AzureRoles / .AzureRolesActive).
 
         # One live eligible assignment expiring in 5 days (inside the 14-day window)
         Mock -ModuleName EasyPIM.Orchestrator Get-PIMAzureResourceEligibleAssignment {

--- a/tests/orchestrator/Invoke-EasyPIMAssignmentRenewal.Tests.ps1
+++ b/tests/orchestrator/Invoke-EasyPIMAssignmentRenewal.Tests.ps1
@@ -1,0 +1,112 @@
+$OrchestratorPath = Join-Path $PSScriptRoot "..\..\EasyPIM.Orchestrator\EasyPIM.Orchestrator.psd1"
+Import-Module (Join-Path $PSScriptRoot "..\..\EasyPIM\EasyPIM.psd1") -Force
+Import-Module $OrchestratorPath -Force
+
+Describe "Invoke-EasyPIMAssignmentRenewal" -Tag 'Unit' {
+
+    BeforeEach {
+        $script:extendCalls = @()
+
+        # Config: one eligible Reader assignment declared at /subscriptions/sub1
+        $script:cfg = [PSCustomObject]@{
+            Assignments = [PSCustomObject]@{
+                AzureRoles = @(
+                    [PSCustomObject]@{
+                        RoleName = "Reader"
+                        Scope    = "/subscriptions/sub1"
+                        assignments = @(
+                            [PSCustomObject]@{ principalId = "11111111-1111-1111-1111-111111111111"; assignmentType = "Eligible" }
+                        )
+                    }
+                )
+            }
+        }
+
+        Mock -ModuleName EasyPIM.Orchestrator Get-EasyPIMConfiguration { return $script:cfg }
+        Mock -ModuleName EasyPIM.Orchestrator Initialize-EasyPIMAssignments { param($Config) return $script:cfg }
+
+        # One live eligible assignment expiring in 5 days (inside the 14-day window)
+        Mock -ModuleName EasyPIM.Orchestrator Get-PIMAzureResourceEligibleAssignment {
+            return @([PSCustomObject]@{
+                PrincipalId = "11111111-1111-1111-1111-111111111111"
+                RoleName    = "Reader"
+                ScopeId     = "/subscriptions/sub1"
+                Status      = "Provisioned"
+                endDateTime = (Get-Date).ToUniversalTime().AddDays(5).ToString("yyyy-MM-ddTHH:mm:ssZ")
+                id          = "/subscriptions/sub1/providers/Microsoft.Authorization/roleEligibilityScheduleInstances/inst-guid"
+            })
+        }
+        Mock -ModuleName EasyPIM.Orchestrator Get-PIMAzureResourceActiveAssignment { return @() }
+
+        Mock -ModuleName EasyPIM.Orchestrator Get-PIMAzureResourcePolicy {
+            return [PSCustomObject]@{
+                MaximumEligibleAssignmentDuration = "P365D"
+                AllowPermanentEligibleAssignment  = "false"
+                MaximumActiveAssignmentDuration   = "P30D"
+                AllowPermanentActiveAssignment    = "false"
+            }
+        }
+
+        Mock -ModuleName EasyPIM.Orchestrator Update-PIMAzureResourceEligibleAssignment {
+            param($tenantID, $subscriptionID, $scope, $principalID, $rolename, $newEndDateTime, $justification)
+            $script:extendCalls += [PSCustomObject]@{ role = $rolename; principal = $principalID; newEnd = $newEndDateTime }
+        }
+        Mock -ModuleName EasyPIM.Orchestrator Update-PIMAzureResourceActiveAssignment {}
+    }
+
+    It "Extends an eligible assignment expiring within the threshold" {
+        $result = Invoke-EasyPIMAssignmentRenewal -ConfigFilePath "dummy.json" `
+            -TenantId "00000000-0000-0000-0000-000000000000" -SubscriptionId "sub1"
+
+        $script:extendCalls.Count | Should -Be 1
+        $script:extendCalls[0].role | Should -Be "Reader"
+        $result.Extended | Should -Be 1
+        $result.FoundExpiring | Should -Be 1
+    }
+
+    It "Does not call the core extend cmdlet under -WhatIf" {
+        $result = Invoke-EasyPIMAssignmentRenewal -ConfigFilePath "dummy.json" `
+            -TenantId "00000000-0000-0000-0000-000000000000" -SubscriptionId "sub1" -WhatIf
+
+        $script:extendCalls.Count | Should -Be 0
+        $result.FoundExpiring | Should -Be 1
+    }
+
+    It "Skips assignments not expiring within the threshold" {
+        Mock -ModuleName EasyPIM.Orchestrator Get-PIMAzureResourceEligibleAssignment {
+            return @([PSCustomObject]@{
+                PrincipalId = "11111111-1111-1111-1111-111111111111"
+                RoleName    = "Reader"
+                ScopeId     = "/subscriptions/sub1"
+                Status      = "Provisioned"
+                endDateTime = (Get-Date).ToUniversalTime().AddDays(90).ToString("yyyy-MM-ddTHH:mm:ssZ")
+                id          = "inst-guid"
+            })
+        }
+
+        $result = Invoke-EasyPIMAssignmentRenewal -ConfigFilePath "dummy.json" `
+            -TenantId "00000000-0000-0000-0000-000000000000" -SubscriptionId "sub1"
+
+        $script:extendCalls.Count | Should -Be 0
+        $result.FoundExpiring | Should -Be 0
+    }
+
+    It "Ignores live assignments not declared in config" {
+        Mock -ModuleName EasyPIM.Orchestrator Get-PIMAzureResourceEligibleAssignment {
+            return @([PSCustomObject]@{
+                PrincipalId = "99999999-9999-9999-9999-999999999999"  # not in config
+                RoleName    = "Reader"
+                ScopeId     = "/subscriptions/sub1"
+                Status      = "Provisioned"
+                endDateTime = (Get-Date).ToUniversalTime().AddDays(5).ToString("yyyy-MM-ddTHH:mm:ssZ")
+                id          = "inst-guid"
+            })
+        }
+
+        $result = Invoke-EasyPIMAssignmentRenewal -ConfigFilePath "dummy.json" `
+            -TenantId "00000000-0000-0000-0000-000000000000" -SubscriptionId "sub1"
+
+        $script:extendCalls.Count | Should -Be 0
+        $result.FoundExpiring | Should -Be 0
+    }
+}


### PR DESCRIPTION
## Summary

  Adds a schedulable, config-driven command that proactively **extends Azure resource
  role PIM assignments before they expire**, so time-bound eligible/active assignments
  declared in an orchestrator config stop lapsing and needing manual renewal.

  New public commands:

  | Command | Module | Purpose |
  | --- | --- | --- |
  | `Invoke-EasyPIMAssignmentRenewal` | EasyPIM.Orchestrator | Reads an orchestrator config, finds declared assignments expiring within a threshold
  (default 14 days), and extends them. `-WhatIf` aware; returns a summary object. |
  | `Update-PIMAzureResourceEligibleAssignment` | EasyPIM (core) | Submits the ARM `AdminExtend` request for an eligible assignment. |
  | `Update-PIMAzureResourceActiveAssignment` | EasyPIM (core) | Same, for an active assignment. |

  Motivation: PIM's own notification window is 14 days, but there's no unattended way to
  act on it. Admin-initiated `AdminExtend` needs no approval, so this can run in a
  pipeline/runbook. Mirrors the existing `New-PIMAzureResource*Assignment` design.

  ## Scope

  - **v1 is Azure resource roles only.** Entra directory roles and PIM-for-Groups are
    intentionally out of scope but the design leaves room for them.
  - Only assignments **declared in the configuration** are touched; undeclared live
    assignments are never modified. Permanent assignments are skipped.
  - New end date = `now + policy maximum duration` (clamped to the role policy).

  ## Non-breaking

  Strictly additive: no existing function signature, behaviour, or output changes.
  Edits to the `.psm1`/`.psd1` files only append to the export lists; CHANGELOG gains one
  section. Module versions bumped (EasyPIM 2.3.1 → 2.4.0, Orchestrator 1.6.0 → 1.7.0) —
  happy to adjust to your release preference.

  ## Validation

  - Full `tests/pester.ps1` general suite (the CI gate): **7533 tests, 0 failures** —
    PSScriptAnalyzer, Manifest, and FileIntegrity all green with these changes.
  - **Verified live** against a real tenant: a `-WhatIf` sweep, then a real apply that
    extended **15/15** declared expiring assignments via `AdminExtend`
    (`status: Provisioned`), confirmed persisted by re-query. This also confirmed
    `AdminExtend` works well before the 14-day self-service window for admin/API callers.
  - Added Pester tests mirroring the repo style (`tests/functions/Update-PIMAzureResource*Assignment.Tests.ps1`,
    `tests/orchestrator/Invoke-EasyPIMAssignmentRenewal.Tests.ps1`), including a
    culture-regression test (dd/MM locales) for date handling.

  ## Design choices — feedback welcome

  A few decisions I'd like your steer on, happy to change:

  1. **Verb `Update-`** for the extend primitives — there's no approved `Extend`/`Renew`
     verb, so I used `Update` (approved). Open to alternatives.
  2. **Two core cmdlets** (eligible + active) mirroring the `New-PIM*` pair vs. a single
     cmdlet with a type switch.
  3. **New orchestrator cmdlet** vs. folding renewal into `Invoke-EasyPIMOrchestrator`
     as a mode.

  ## Docs

  - New page: `EasyPIM/Documentation/Invoke-EasyPIMAssignmentRenewal.md`.
  - CHANGELOG updated in the existing format.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)